### PR TITLE
Minor code cleanup, and improvements to Message API

### DIFF
--- a/src/main/java/org/zeromq/api/RoutedMessage.java
+++ b/src/main/java/org/zeromq/api/RoutedMessage.java
@@ -4,13 +4,25 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-//NOT THREAD SAFE
+/**
+ * Routed message contains route frames and payload frames.
+ */
 public class RoutedMessage extends Message {
 
     public RoutedMessage() {
 
     }
 
+    /**
+     * Takes a route with no frames.
+     */
+    public RoutedMessage(Route route) {
+        super(route.getRoutingFrames());
+    }
+
+    /**
+     * Takes routes with no frames.
+     */
     public RoutedMessage(List<Route> routes) {
         for (Route route : routes) {
             addFrames(route.getRoutingFrames());
@@ -21,7 +33,7 @@ public class RoutedMessage extends Message {
      * Takes the existing message and adds a route to the beginning of it.
      */
     public RoutedMessage(Route route, Message message) {
-        this(Arrays.asList(route));
+        this(route);
         addFrames(message);
     }
 
@@ -31,12 +43,6 @@ public class RoutedMessage extends Message {
     public RoutedMessage(List<Route> routes, Message message) {
         this(routes);
         addFrames(message);
-    }
-
-    private void addFrames(List<Frame> routingFrames) {
-        for (Frame routingFrame : routingFrames) {
-            addFrame(routingFrame.getData());
-        }
     }
 
     public Message getPayload() {
@@ -84,12 +90,20 @@ public class RoutedMessage extends Message {
         //todo store Frame or bytes?
         private final byte[] address;
 
+        public Route(String address) {
+            this(address.getBytes());
+        }
+
         public Route(byte[] address) {
             this.address = address;
         }
 
         public byte[] getAddress() {
             return address;
+        }
+
+        public String getString() {
+            return new String(address);
         }
 
         public List<Frame> getRoutingFrames() {

--- a/src/main/java/org/zeromq/jzmq/ManagedSocket.java
+++ b/src/main/java/org/zeromq/jzmq/ManagedSocket.java
@@ -1,12 +1,18 @@
 package org.zeromq.jzmq;
 
-import org.zeromq.ZMQ;
-import org.zeromq.api.*;
-
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.zeromq.ZMQ;
+import org.zeromq.api.Context;
+import org.zeromq.api.Message;
+import org.zeromq.api.Message.Frame;
+import org.zeromq.api.MessageFlag;
+import org.zeromq.api.RoutedMessage;
+import org.zeromq.api.Socket;
+import org.zeromq.api.TransportType;
 
 /**
  * Managed JZMQ Socket
@@ -29,6 +35,7 @@ public class ManagedSocket implements Socket {
         this.managedContext.addSocket(this);
     }
 
+    @Override
     public ZMQ.Socket getZMQSocket() {
         return socket;
     }
@@ -79,10 +86,10 @@ public class ManagedSocket implements Socket {
         if (bytes == null) {
             return null;
         }
-        result.addFrame(bytes);
+        result.addFrame(new Frame(bytes));
         while (hasMoreToReceive()) {
             byte[] data = receive();
-            result.addFrame(data);
+            result.addFrame(new Frame(data));
         }
         return result;
     }

--- a/src/main/java/org/zeromq/jzmq/Poller.java
+++ b/src/main/java/org/zeromq/jzmq/Poller.java
@@ -24,10 +24,10 @@ public class Poller {
             Socket socket = pollable.getSocket();
             int options = sumOptions(pollable);
             int index = poller.register(socket.getZMQSocket(), options);
-            socketIndex.put(index, socket);
+            socketIndex.put(Integer.valueOf(index), socket);
 
             PollListener listener = entry.getValue();
-            listeners.put(index, listener);
+            listeners.put(Integer.valueOf(index), listener);
         }
     }
 
@@ -47,13 +47,13 @@ public class Poller {
         }
         for (Map.Entry<Integer, Socket> entry : socketIndex.entrySet()) {
             Integer index = entry.getKey();
-            if (poller.pollin(index)) {
+            if (poller.pollin(index.intValue())) {
                 listeners.get(index).handleIn(entry.getValue());
             }
-            if (poller.pollout(index)) {
+            if (poller.pollout(index.intValue())) {
                 listeners.get(index).handleOut(entry.getValue());
             }
-            if (poller.pollerr(index)) {
+            if (poller.pollerr(index.intValue())) {
                 listeners.get(index).handleError(entry.getValue());
             }
         }

--- a/src/main/java/org/zeromq/jzmq/sockets/PairSocketBuilder.java
+++ b/src/main/java/org/zeromq/jzmq/sockets/PairSocketBuilder.java
@@ -1,0 +1,12 @@
+package org.zeromq.jzmq.sockets;
+
+import org.zeromq.api.SocketType;
+import org.zeromq.jzmq.ManagedContext;
+
+public class PairSocketBuilder extends SocketBuilder {
+
+    public PairSocketBuilder(ManagedContext context) {
+        super(context, SocketType.PAIR);
+    }
+
+}

--- a/src/main/java/org/zeromq/jzmq/sockets/SocketBuilder.java
+++ b/src/main/java/org/zeromq/jzmq/sockets/SocketBuilder.java
@@ -179,6 +179,7 @@ public class SocketBuilder implements Bindable, Connectable {
     /**
      * {@inheritDoc}
      */
+    @Override
     public Socket connect(String url) {
         ZMQ.Socket socket = createConnectableSocketWithStandardSettings();
         socket.connect(url);
@@ -202,6 +203,7 @@ public class SocketBuilder implements Bindable, Connectable {
     /**
      * {@inheritDoc}
      */
+    @Override
     public Socket bind(String url, String... additionalUrls) {
         ZMQ.Socket socket = createBindableSocketWithStandardSettings();
         bind(socket, url, additionalUrls);

--- a/src/test/java/guide/lbbroker2.java
+++ b/src/test/java/guide/lbbroker2.java
@@ -56,7 +56,7 @@ public class lbbroker2 {
                 if (message == null) {
                     continue;
                 }
-                System.out.println("Worker: " + new String(message.getPayload().getFirstFrame()));
+                System.out.println("Worker: " + new String(message.getPayload().getFirstFrame().getData()));
                 List<RoutedMessage.Route> routes = message.getRoutes();
                 worker.send(new RoutedMessage(routes, new Message("OK".getBytes())));
             }
@@ -109,7 +109,7 @@ public class lbbroker2 {
                     workerQueue.add(topRoute);
 
                     Message payload = routedMessage.getPayload();
-                    byte[] clientAddress = payload.getFirstFrame();
+                    byte[] clientAddress = payload.getFirstFrame().getData();
                     if (!Arrays.equals(READY, clientAddress)) {
                         frontend.send(new RoutedMessage(routedMessage.getRoutes(), payload));
 

--- a/src/test/java/org/zeromq/api/DealerRepTest.java
+++ b/src/test/java/org/zeromq/api/DealerRepTest.java
@@ -12,11 +12,13 @@ public class DealerRepTest extends TestCase {
     private Context context;
 
     @Before
+    @Override
     public void setUp() {
         context = ContextFactory.createContext(1);
     }
 
     @After
+    @Override
     public void tearDown() throws Exception {
         context.close();
     }

--- a/src/test/java/org/zeromq/api/MessageTest.java
+++ b/src/test/java/org/zeromq/api/MessageTest.java
@@ -1,18 +1,19 @@
 package org.zeromq.api;
 
-import org.junit.Test;
+import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertArrayEquals;
 
 import java.util.List;
 
-import static junit.framework.Assert.assertEquals;
-import static org.junit.Assert.assertArrayEquals;
+import org.junit.Test;
+import org.zeromq.api.Message.Frame;
 
 public class MessageTest {
 
     @Test
     public void testAddFrame() throws Exception {
         Message testClass = new Message();
-        testClass.addFrame(new byte[]{5, 6, 7});
+        testClass.addFrame(new Frame(new byte[]{5, 6, 7}));
         List<Message.Frame> frames = testClass.getFrames();
         assertEquals(1, frames.size());
         assertArrayEquals(new byte[]{5, 6, 7}, frames.get(0).getData());
@@ -31,7 +32,7 @@ public class MessageTest {
     public void testMixedFrames() throws Exception {
         Message testClass = new Message();
         testClass.addEmptyFrame();
-        testClass.addFrame("Hello".getBytes());
+        testClass.addFrame(new Frame("Hello"));
         List<Message.Frame> frames = testClass.getFrames();
         assertEquals(2, frames.size());
         assertArrayEquals(new byte[0], frames.get(0).getData());
@@ -41,9 +42,9 @@ public class MessageTest {
     @Test
     public void testCopyConstructor() throws Exception {
         Message initial = new Message();
-        initial.addFrame("hello".getBytes());
+        initial.addFrame(new Frame("hello"));
         initial.addEmptyFrame();
-        initial.addFrame("goodbye".getBytes());
+        initial.addFrame(new Frame("goodbye"));
 
         Message newMessage = new Message(initial);
         assertEquals(initial.getFrames(), newMessage.getFrames());

--- a/src/test/java/org/zeromq/api/PushPullTest.java
+++ b/src/test/java/org/zeromq/api/PushPullTest.java
@@ -10,11 +10,13 @@ public class PushPullTest extends TestCase {
     private Context context;
 
     @Before
+    @Override
     public void setUp() {
         context = ContextFactory.createContext(1);
     }
 
     @After
+    @Override
     public void tearDown() throws Exception {
         context.close();
     }

--- a/src/test/java/org/zeromq/api/RoutedMessageTest.java
+++ b/src/test/java/org/zeromq/api/RoutedMessageTest.java
@@ -1,15 +1,16 @@
 package org.zeromq.api;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertArrayEquals;
 
 import java.util.Arrays;
 import java.util.List;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertTrue;
-import static org.junit.Assert.assertArrayEquals;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.zeromq.api.Message.Frame;
 
 public class RoutedMessageTest {
 
@@ -56,13 +57,13 @@ public class RoutedMessageTest {
                 new Message.Frame("payload".getBytes()))));
 
         Message result = testClass.getPayload();
-        assertArrayEquals("payload".getBytes(), result.getFirstFrame());
+        assertArrayEquals("payload".getBytes(), result.getFirstFrame().getData());
     }
 
     @Test
     public void testGetRoutes_noRoutes() throws Exception {
         RoutedMessage testClass = new RoutedMessage();
-        testClass.addFrame("payload".getBytes());
+        testClass.addFrame(new Frame("payload"));
 
         List<RoutedMessage.Route> result = testClass.getRoutes();
         assertTrue(result.isEmpty());
@@ -71,7 +72,7 @@ public class RoutedMessageTest {
     @Test
     public void testUnwrap_noRoutes() throws Exception {
         RoutedMessage testClass = new RoutedMessage();
-        testClass.addFrame("payload".getBytes());
+        testClass.addFrame(new Frame("payload"));
 
         expectedException.expect(IllegalStateException.class);
         expectedException.expectMessage("Cannot unwrap an unrouted message.");

--- a/src/test/java/org/zeromq/api/RouterDealerTest.java
+++ b/src/test/java/org/zeromq/api/RouterDealerTest.java
@@ -11,11 +11,13 @@ public class RouterDealerTest extends TestCase {
     private Context context;
 
     @Before
+    @Override
     public void setUp() {
         context = ContextFactory.createContext(1);
     }
 
     @After
+    @Override
     public void tearDown() throws Exception {
         context.close();
     }


### PR DESCRIPTION
I'm working on integrating some patterns from the ZGuide into the API, which I hope will be worth a pull request at some point. But first I wanted to make some improvements to various API elements, starting with Message/RoutedMessage/Frame. Feedback welcome. Some things:
- I changed a few API elements, broke backwards compatibility, and so updated some tests
- I performed a few code cleanups in this commit as well
- Made Frame constructor public but didn't move it to it's own java file

Any problems with breaking backwards compatibility, please let me know.
