### PR TITLE
Feature/clone pattern - part 1 & 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,4 @@ language: java
 script: mvn test
 
 jdk:
- - openjdk6
  - openjdk7

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
         <dependency>
           <groupId>org.zeromq</groupId>
           <artifactId>jzmq</artifactId>
-          <version>3.1.0</version>
+          <version>3.1.1-SNAPSHOT</version>
         </dependency>
       </dependencies>
     </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
         <dependency>
           <groupId>org.zeromq</groupId>
           <artifactId>jzmq</artifactId>
-          <version>3.1.1-SNAPSHOT</version>
+          <version>3.1.0</version>
         </dependency>
       </dependencies>
     </profile>
@@ -128,7 +128,7 @@
         <dependency>
           <groupId>org.zeromq</groupId>
           <artifactId>jeromq</artifactId>
-          <version>0.3.5-SNAPSHOT</version>
+          <version>0.3.5</version>
         </dependency>
       </dependencies>
     </profile>

--- a/src/main/java/org/zeromq/api/BeaconListener.java
+++ b/src/main/java/org/zeromq/api/BeaconListener.java
@@ -1,0 +1,16 @@
+package org.zeromq.api;
+
+import java.net.InetAddress;
+
+/**
+ * Listener to handle beacon events sent via UDP.
+ */
+public interface BeaconListener {
+    /**
+     * Handle a validated beacon event.
+     * 
+     * @param sender The sender of the beacon
+     * @param beacon The beacon, containing connection information
+     */
+    void onBeacon(InetAddress sender, UdpBeacon beacon);
+}

--- a/src/main/java/org/zeromq/api/BeaconReactor.java
+++ b/src/main/java/org/zeromq/api/BeaconReactor.java
@@ -1,0 +1,13 @@
+package org.zeromq.api;
+
+public interface BeaconReactor {
+    /**
+     * Start the underlying Reactor.
+     */
+    void start();
+
+    /**
+     * Stop the underlying Reactor.
+     */
+    void stop();
+}

--- a/src/main/java/org/zeromq/api/BinaryStar.java
+++ b/src/main/java/org/zeromq/api/BinaryStar.java
@@ -73,6 +73,11 @@ public interface BinaryStar {
     void start();
 
     /**
+     * Stop the underlying Reactor.
+     */
+    void stop();
+
+    /**
      * Register a client voter socket. Only one socket can be registered.
      *
      * @param socket The client socket

--- a/src/main/java/org/zeromq/api/BinaryStar.java
+++ b/src/main/java/org/zeromq/api/BinaryStar.java
@@ -6,6 +6,11 @@ package org.zeromq.api;
  */
 public interface BinaryStar {
     /**
+     * We send state information this often. If peer doesn't respond in two heartbeats, it is 'dead'.
+     */
+    long BSTAR_HEARTBEAT = 1000;
+
+    /**
      * Startup modes.
      */
     enum Mode {
@@ -114,4 +119,11 @@ public interface BinaryStar {
      * @return The underlying Reactor
      */
     Reactor getReactor();
+
+    /**
+     * Set the heartbeat interval used to detect peer outage.
+     * 
+     * @param heartbeatInterval The heartbeat interval, in milliseconds
+     */
+    void setHeartbeatInterval(long heartbeatInterval);
 }

--- a/src/main/java/org/zeromq/api/BinaryStar.java
+++ b/src/main/java/org/zeromq/api/BinaryStar.java
@@ -1,0 +1,112 @@
+package org.zeromq.api;
+
+/**
+ * Reactor implementing the Binary Star pattern, used to construct HA-pairs
+ * that can forward messages to an application in an event-driven manner.
+ */
+public interface BinaryStar {
+    /**
+     * Startup modes.
+     */
+    enum Mode {
+        /**
+         * Primary node.
+         */
+        PRIMARY,
+        /**
+         * Backup node.
+         */
+        BACKUP
+    }
+
+    /**
+     * States we can be in at any point in time.
+     */
+    enum State {
+        /**
+         * Primary, waiting for peer to connect.
+         */
+        PRIMARY_CONNECTING,
+        /**
+         * Backup, waiting for peer to connect.
+         */
+        BACKUP_CONNECTING,
+        /**
+         * Active - accepting connections.
+         */
+        ACTIVE,
+        /**
+         * Passive - Not accepting connections.
+         */
+        PASSIVE
+    }
+
+    /**
+     * Events, which start with the states our peer can be in.
+     */
+    enum Event {
+        /**
+         * HA peer is pending primary.
+         */
+        PEER_PRIMARY,
+        /**
+         * HA peer is pending backup.
+         */
+        PEER_BACKUP,
+        /**
+         * HA peer is active.
+         */
+        PEER_ACTIVE,
+        /**
+         * HA peer is passive.
+         */
+        PEER_PASSIVE,
+        /**
+         * Client makes request.
+         */
+        CLIENT_REQUEST
+    }
+
+    /**
+     * Start the underlying Reactor.
+     */
+    void start();
+
+    /**
+     * Register a client voter socket. Only one socket can be registered.
+     *
+     * @param socket The client socket
+     */
+    void registerVoterSocket(Socket socket);
+
+    /**
+     * Register a voter handler to be called each time the application receives a message.
+     *
+     * @param handler The handler for client events
+     * @param args Arguments passed to the handler
+     */
+    void setVoterHandler(LoopHandler handler, Object... args);
+
+    /**
+     * Register a handler to be called each time there's a state change.
+     *
+     * @param handler The handler for state change events
+     * @param args Arguments passed to the handler
+     */
+    void setActiveHandler(LoopHandler handler, Object... args);
+
+    /**
+     * Register a handler to be called each time there's a state change.
+     *
+     * @param handler The handler for state change events
+     * @param args Arguments passed to the handler
+     */
+    void setPassiveHandler(LoopHandler handler, Object... args);
+
+    /**
+     * Get the underlying {@link Reactor}.
+     * 
+     * @return The underlying Reactor
+     */
+    Reactor getReactor();
+}

--- a/src/main/java/org/zeromq/api/BinaryStarReactor.java
+++ b/src/main/java/org/zeromq/api/BinaryStarReactor.java
@@ -4,7 +4,7 @@ package org.zeromq.api;
  * Reactor implementing the Binary Star pattern, used to construct HA-pairs
  * that can forward messages to an application in an event-driven manner.
  */
-public interface BinaryStar {
+public interface BinaryStarReactor {
     /**
      * We send state information this often. If peer doesn't respond in two heartbeats, it is 'dead'.
      */

--- a/src/main/java/org/zeromq/api/Bits.java
+++ b/src/main/java/org/zeromq/api/Bits.java
@@ -1,0 +1,39 @@
+package org.zeromq.api;
+
+class Bits {
+    public static int getInt(byte[] buf) {
+        return ((buf[0] & 0xff) << 24)
+            + ((buf[1] & 0xff) << 16)
+            + ((buf[2] & 0xff) << 8)
+            + ((buf[3] & 0xff));
+    }
+
+    public static void putInt(byte[] buf, int val) {
+        buf[0] = (byte) (val >> 24);
+        buf[1] = (byte) (val >> 16);
+        buf[2] = (byte) (val >> 8);
+        buf[3] = (byte) (val);
+    }
+
+    public static long getLong(byte[] buf) {
+        return ((long) (buf[0] & 0xff) << 56)
+            + ((long) (buf[1] & 0xff) << 48)
+            + ((long) (buf[2] & 0xff) << 40)
+            + ((long) (buf[3] & 0xff) << 32)
+            + ((buf[4] & 0xff) << 24)
+            + ((buf[5] & 0xff) << 16)
+            + ((buf[6] & 0xff) << 8)
+            + ((buf[7] & 0xff));
+    }
+
+    public static void putLong(byte[] buf, long val) {
+        buf[0] = (byte) (val >> 56);
+        buf[1] = (byte) (val >> 48);
+        buf[2] = (byte) (val >> 40);
+        buf[3] = (byte) (val >> 32);
+        buf[4] = (byte) (val >> 24);
+        buf[5] = (byte) (val >> 16);
+        buf[6] = (byte) (val >> 8);
+        buf[7] = (byte) (val);
+    }
+}

--- a/src/main/java/org/zeromq/api/Context.java
+++ b/src/main/java/org/zeromq/api/Context.java
@@ -52,18 +52,18 @@ public interface Context extends Closeable {
     ReactorBuilder buildReactor();
 
     /**
-     * Create a new BinaryStar, which will create one half of an HA-pair
+     * Create a new BinaryStarReactor, which will create one half of an HA-pair
      * with event-driven polling of a client Socket.
      * 
-     * @return A builder for constructing a BinaryStar
+     * @return A builder for constructing a BinaryStarReactor
      */
-    BinaryStarBuilder buildBinaryStar();
+    BinaryStarBuilder buildBinaryStarReactor();
 
     /**
      * Create a ØMQ Socket, backed by a background agent that is connecting
-     * to a BinaryStar HA-pair.
+     * to a BinaryStarReactor HA-pair.
      *
-     * @return A builder for constructing connecting a BinaryStar client Socket
+     * @return A builder for constructing connecting a BinaryStarReactor client Socket
      */
     BinaryStarSocketBuilder buildBinaryStarSocket();
 

--- a/src/main/java/org/zeromq/api/Context.java
+++ b/src/main/java/org/zeromq/api/Context.java
@@ -60,6 +60,14 @@ public interface Context extends Closeable {
      * @param frontEnd The front-end socket which will be proxied to/from the back-end
      * @param backEnd The back-end socket which will be proxied to/from the front-end
      */
+    void forward(Socket frontEnd, Socket backEnd);
+
+    /**
+     * Alias of {@link #forward}.
+     *
+     * @param frontEnd The front-end socket which will be proxied to/from the back-end
+     * @param backEnd The back-end socket which will be proxied to/from the front-end
+     */
     void queue(Socket frontEnd, Socket backEnd);
 
     /**

--- a/src/main/java/org/zeromq/api/Context.java
+++ b/src/main/java/org/zeromq/api/Context.java
@@ -1,11 +1,15 @@
 package org.zeromq.api;
 
+import org.zeromq.jzmq.beacon.BeaconReactorBuilder;
 import org.zeromq.jzmq.bstar.BinaryStarBuilder;
+import org.zeromq.jzmq.bstar.BinaryStarSocketBuilder;
+import org.zeromq.jzmq.device.DeviceBuilder;
 import org.zeromq.jzmq.poll.PollerBuilder;
 import org.zeromq.jzmq.reactor.ReactorBuilder;
 import org.zeromq.jzmq.sockets.SocketBuilder;
 
 import java.io.Closeable;
+import java.nio.channels.SelectableChannel;
 
 /**
  * A ØMQ context is thread safe and may be shared among as many application threads as necessary, without any additional
@@ -56,6 +60,31 @@ public interface Context extends Closeable {
     BinaryStarBuilder buildBinaryStar();
 
     /**
+     * Create a ØMQ Socket, backed by a background agent that is connecting
+     * to a BinaryStar HA-pair.
+     *
+     * @return A builder for constructing connecting a BinaryStar client Socket
+     */
+    BinaryStarSocketBuilder buildBinaryStarSocket();
+
+    /**
+     * Create a new BeaconReactor, which will send and receive UDP beacons
+     * on a broadcast address, with event-driven handling of received beacons.
+     * 
+     * @return A builder for constructing a BeaconReactor
+     */
+    BeaconReactorBuilder buildBeaconReactor();
+
+    /**
+     * Create a ØMQ Device of type DeviceType, which will bridge two networks
+     * together using patterns for specific SocketTypes.
+     *
+     * @param deviceType The device type, specifying the pattern to use
+     * @return A builder for constructing ØMQ Devices
+     */
+    DeviceBuilder buildDevice(DeviceType deviceType);
+
+    /**
      * Create a new Pollable from the socket, with the requested options.
      * 
      * @param socket A socket to wrap for polling
@@ -63,6 +92,15 @@ public interface Context extends Closeable {
      * @return A new Pollable, for use with a Poller.
      */
     Pollable newPollable(Socket socket, PollerType... options);
+
+    /**
+     * Create a new Pollable from the socket, with the requested options.
+     *
+     * @param channel A channel to wrap for polling
+     * @param options Polling options (IN, OUT, ERROR)
+     * @return A new Pollable, for use with a Poller.
+     */
+    Pollable newPollable(SelectableChannel channel, PollerType... options);
 
     /**
      * Create a ZMQ proxy and start it up.  Returns when the context is closed.

--- a/src/main/java/org/zeromq/api/Context.java
+++ b/src/main/java/org/zeromq/api/Context.java
@@ -103,4 +103,10 @@ public interface Context extends Closeable {
      * Close the context and any open sockets.
      */
     void close();
+
+    /**
+     * Asynchronously terminate the context without closing any open sockets,
+     * forcing pollers and waiters to abort.
+     */
+    void terminate();
 }

--- a/src/main/java/org/zeromq/api/Context.java
+++ b/src/main/java/org/zeromq/api/Context.java
@@ -1,6 +1,8 @@
 package org.zeromq.api;
 
+import org.zeromq.jzmq.bstar.BinaryStarBuilder;
 import org.zeromq.jzmq.poll.PollerBuilder;
+import org.zeromq.jzmq.reactor.ReactorBuilder;
 import org.zeromq.jzmq.sockets.SocketBuilder;
 
 import java.io.Closeable;
@@ -14,7 +16,7 @@ public interface Context extends Closeable {
      * Create a ØMQ Socket of type SocketType
      * 
      * @param type socket type
-     * @return builder object
+     * @return A builder for constructing and connecting ØMQ Sockets
      */
     SocketBuilder buildSocket(SocketType type);
 
@@ -31,10 +33,27 @@ public interface Context extends Closeable {
     /**
      * Create a new Poller, which will allow callback-based polling of Sockets.
      * 
+     * @return A builder for constructing ØMQ Pollers
      * @see Pollable
      * @see PollerType
      */
     PollerBuilder buildPoller();
+
+    /**
+     * Create a new Reactor, which will allow event-driven and timer-based
+     * polling of Sockets.
+     * 
+     * @return A builder for constructing a Reactor
+     */
+    ReactorBuilder buildReactor();
+
+    /**
+     * Create a new BinaryStar, which will create one half of an HA-pair
+     * with event-driven polling of a client Socket.
+     * 
+     * @return A builder for constructing a BinaryStar
+     */
+    BinaryStarBuilder buildBinaryStar();
 
     /**
      * Create a new Pollable from the socket, with the requested options.

--- a/src/main/java/org/zeromq/api/DeviceType.java
+++ b/src/main/java/org/zeromq/api/DeviceType.java
@@ -23,7 +23,7 @@ public enum DeviceType {
 
     private final int type;
 
-    private DeviceType(int type) {
+    DeviceType(int type) {
         this.type = type;
     }
 

--- a/src/main/java/org/zeromq/api/LoopHandler.java
+++ b/src/main/java/org/zeromq/api/LoopHandler.java
@@ -7,8 +7,9 @@ public interface LoopHandler {
     /**
      * Execute a loop operation.
      * 
-     * @param socket The Socket
+     * @param reactor The Reactor
+     * @param pollable The Pollable containing the socket or channel
      * @param args Optional arguments
      */
-    void execute(Reactor reactor, Socket socket, Object... args);
+    void execute(Reactor reactor, Pollable pollable, Object... args);
 }

--- a/src/main/java/org/zeromq/api/LoopHandler.java
+++ b/src/main/java/org/zeromq/api/LoopHandler.java
@@ -1,0 +1,14 @@
+package org.zeromq.api;
+
+/**
+ * Callback from within an event-driven reactor.
+ */
+public interface LoopHandler {
+    /**
+     * Execute a loop operation.
+     * 
+     * @param socket The Socket
+     * @param args Optional arguments
+     */
+    void execute(Reactor reactor, Socket socket, Object... args);
+}

--- a/src/main/java/org/zeromq/api/PollAdapter.java
+++ b/src/main/java/org/zeromq/api/PollAdapter.java
@@ -1,16 +1,41 @@
 package org.zeromq.api;
 
+import java.nio.channels.SelectableChannel;
+
 public class PollAdapter implements PollListener {
-
     @Override
-    public void handleIn(Socket socket) {
+    public void handleIn(Pollable pollable) {
+        handleIn(pollable.getSocket());
+        handleIn(pollable.getChannel());
     }
 
     @Override
-    public void handleOut(Socket socket) {
+    public void handleOut(Pollable pollable) {
+        handleOut(pollable.getSocket());
+        handleOut(pollable.getChannel());
     }
 
     @Override
-    public void handleError(Socket socket) {
+    public void handleError(Pollable pollable) {
+        handleError(pollable.getSocket());
+        handleError(pollable.getChannel());
+    }
+
+    protected void handleIn(Socket socket) {
+    }
+
+    protected void handleOut(Socket socket) {
+    }
+
+    protected void handleError(Socket socket) {
+    }
+
+    protected void handleIn(SelectableChannel channel) {
+    }
+
+    protected void handleOut(SelectableChannel channel) {
+    }
+
+    protected void handleError(SelectableChannel channel) {
     }
 }

--- a/src/main/java/org/zeromq/api/PollListener.java
+++ b/src/main/java/org/zeromq/api/PollListener.java
@@ -1,7 +1,7 @@
 package org.zeromq.api;
 
 public interface PollListener {
-    void handleIn(Socket socket);
-    void handleOut(Socket socket);
-    void handleError(Socket socket);
+    void handleIn(Pollable pollable);
+    void handleOut(Pollable pollable);
+    void handleError(Pollable pollable);
 }

--- a/src/main/java/org/zeromq/api/Pollable.java
+++ b/src/main/java/org/zeromq/api/Pollable.java
@@ -1,10 +1,13 @@
 package org.zeromq.api;
 
+import java.nio.channels.SelectableChannel;
 import java.util.EnumSet;
 
 public interface Pollable {
 
     Socket getSocket();
+
+    SelectableChannel getChannel();
 
     EnumSet<PollerType> getOptions();
 }

--- a/src/main/java/org/zeromq/api/Poller.java
+++ b/src/main/java/org/zeromq/api/Poller.java
@@ -34,4 +34,13 @@ public interface Poller {
      */
     boolean disable(Socket socket);
 
+    /**
+     * Enable a socket in the poller after it has been disabled.
+     *
+     * @param pollable The pollable containing the socket and polling options
+     * @param listener The listener that handles events for the given pollable
+     * @return The new index of the socket in the poller, for reference
+     */
+    int register(Pollable pollable, PollListener listener);
+
 }

--- a/src/main/java/org/zeromq/api/Poller.java
+++ b/src/main/java/org/zeromq/api/Poller.java
@@ -1,5 +1,7 @@
 package org.zeromq.api;
 
+import java.nio.channels.SelectableChannel;
+
 /**
  * Poller for polling sockets and receiving callbacks for events.
  */
@@ -33,6 +35,23 @@ public interface Poller {
      * @return true if the socket was disabled, false otherwise
      */
     boolean disable(Socket socket);
+
+    /**
+     * Enable a channel in the poller after it has been disabled.
+     *
+     * @param channel The channel registered with the poller to be enabled
+     * @return The new index of the socket in the poller, for reference
+     */
+    int enable(SelectableChannel channel);
+
+    /**
+     * Disable a channel in the poller, preventing it from waking up the thread
+     * when messages are received on it.
+     *
+     * @param channel The channel registered with the poller to be disabled
+     * @return true if the socket was disabled, false otherwise
+     */
+    boolean disable(SelectableChannel channel);
 
     /**
      * Enable a socket in the poller after it has been disabled.

--- a/src/main/java/org/zeromq/api/Reactor.java
+++ b/src/main/java/org/zeromq/api/Reactor.java
@@ -1,0 +1,47 @@
+package org.zeromq.api;
+
+/**
+ * An event-driven reactor.
+ */
+public interface Reactor {
+    /**
+     * Start the reactor
+     */
+    void start();
+
+    /**
+     * Add a new Pollable to this Reactor.
+     * <p>
+     * This method is not thread-safe, and should only be done from inside the
+     * LoopHandler when invoked by the Reactor on its own thread.
+     * 
+     * @param pollable The Pollable with the socket to poll
+     * @param handler The loop handler
+     * @param args Optional arguments
+     */
+    void addPollable(Pollable pollable, LoopHandler handler, Object... args);
+
+    /**
+     * Add a new ReactorTimer to this Reactor.
+     * <p>
+     * This method is not thread-safe, and should only be done from inside the
+     * LoopHandler when invoked by the Reactor on its own thread.
+     * 
+     * @param initialDelay The initial delay, in milliseconds
+     * @param numIterations The number of iterations, after which this timer stop
+     * @param handler The loop handler
+     * @param args Optional arguments
+     */
+    void addTimer(long initialDelay, int numIterations, LoopHandler handler, Object... args);
+
+    /**
+     * Cancel an existing Pollable or ReactorTimer and remove the corresponding
+     * LoopHandler from executing.
+     * <p>
+     * This method is not thread-safe, and should only be done from inside the
+     * LoopHandler when invoked by the Reactor on its own thread.
+     * 
+     * @param handler The loop handler
+     */
+    void cancel(LoopHandler handler);
+}

--- a/src/main/java/org/zeromq/api/Reactor.java
+++ b/src/main/java/org/zeromq/api/Reactor.java
@@ -10,6 +10,11 @@ public interface Reactor {
     void start();
 
     /**
+     * Start the reactor
+     */
+    void stop();
+
+    /**
      * Add a new Pollable to this Reactor.
      * <p>
      * This method is not thread-safe, and should only be done from inside the

--- a/src/main/java/org/zeromq/api/Receiver.java
+++ b/src/main/java/org/zeromq/api/Receiver.java
@@ -56,10 +56,27 @@ public interface Receiver {
     Message receiveMessage();
 
     /**
+     * Receive the full message (all frames) from the socket.
+     * 
+     * @param flag Flag controlling behavior of the receive operation
+     * @return The full message (all frames) from the socket.
+     */
+    Message receiveMessage(MessageFlag flag);
+
+    /**
      * Receive a routed message (all frames) from the socket.
      * 
      * @return The full message (all frames) from the socket, assuming it has been through a Router socket, and has
      * routing frames associated with it.
      */
     RoutedMessage receiveRoutedMessage();
+
+    /**
+     * Receive a routed message (all frames) from the socket.
+     * 
+     * @param flag Flag controlling behavior of the receive operation
+     * @return The full message (all frames) from the socket, assuming it has been through a Router socket, and has
+     * routing frames associated with it.
+     */
+    RoutedMessage receiveRoutedMessage(MessageFlag flag);
 }

--- a/src/main/java/org/zeromq/api/Subscribable.java
+++ b/src/main/java/org/zeromq/api/Subscribable.java
@@ -4,4 +4,5 @@ import org.zeromq.jzmq.sockets.SocketBuilder;
 
 public interface Subscribable {
     SocketBuilder subscribe(byte[] data);
+    SocketBuilder subscribeAll();
 }

--- a/src/main/java/org/zeromq/api/UdpBeacon.java
+++ b/src/main/java/org/zeromq/api/UdpBeacon.java
@@ -1,0 +1,87 @@
+package org.zeromq.api;
+
+import java.nio.ByteBuffer;
+import java.util.UUID;
+
+public class UdpBeacon {
+    public static final int BEACON_SIZE = 21; // version(1) + uuid(16) + port(2) + protocol_size(2)
+
+    private final byte[] protocol;
+    private final byte version;
+    private final UUID uuid;
+    private final String identity;
+    private final int port;
+
+    private ByteBuffer buffer;
+
+    public UdpBeacon(ByteBuffer buffer) {
+        int blockSize = buffer.getShort();
+        byte[] protocol = new byte[blockSize];
+        buffer.get(protocol);
+        byte version = buffer.get();
+        long msb = buffer.getLong();
+        long lsb = buffer.getLong();
+        UUID uuid = new UUID(msb, lsb);
+        int port = buffer.getShort();
+        if (port < 0)
+            port = (0xffff) & port;
+
+        this.protocol = protocol;
+        this.version = version;
+        this.uuid = uuid;
+        this.port = port;
+        this.identity = uuid.toString().replace("-", "").toUpperCase();
+    }
+
+    public UdpBeacon(byte version, String protocol, int port) {
+        this(version, protocol, UUID.randomUUID(), port);
+    }
+
+    public UdpBeacon(int version, String protocol, UUID uuid, int port) {
+        this.protocol = protocol.getBytes(Message.CHARSET);
+        this.version = (byte) version;
+        this.uuid = uuid;
+        this.port = port;
+        this.identity = uuid.toString().replace("-", "").toUpperCase();
+    }
+
+    public String getProtocol() {
+        return new String(protocol, Message.CHARSET);
+    }
+
+    public int getVersion() {
+        return version;
+    }
+
+    public UUID getUuid() {
+        return uuid;
+    }
+
+    public String getIdentity() {
+        return identity;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public ByteBuffer getBuffer() {
+        if (buffer == null) {
+            buffer = ByteBuffer.allocate(calculateSize());
+            buffer.putShort((short) protocol.length);
+            buffer.put(protocol);
+            buffer.put(version);
+            buffer.putLong(uuid.getMostSignificantBits());
+            buffer.putLong(uuid.getLeastSignificantBits());
+            buffer.putShort((short) port);
+            buffer.flip();
+        }
+
+        buffer.rewind();
+        return buffer;
+    }
+
+    private int calculateSize() {
+        return BEACON_SIZE + protocol.length;
+    }
+}

--- a/src/main/java/org/zeromq/api/ZInteger.java
+++ b/src/main/java/org/zeromq/api/ZInteger.java
@@ -1,0 +1,96 @@
+package org.zeromq.api;
+
+import org.zeromq.api.Message.Frame;
+
+/**
+ * Buffer capable of sending/receiving a 4-byte integer (Java {@code int}). 
+ */
+public class ZInteger {
+    private final byte[] buf = new byte[4];
+
+    /**
+     * Construct an empty buffer (defaults to 0).
+     */
+    public ZInteger() {
+    }
+
+    /**
+     * Construct a buffer with a default value.
+     *
+     * @param val The default value
+     */
+    public ZInteger(int val) {
+        setValue(val);
+    }
+
+    /**
+     * Receive a 4-byte value as a frame of data on the given Socket.
+     * 
+     * @param socket The Socket to read from
+     * @return The integer value received from the Socket
+     */
+    public int receive(Socket socket) {
+        socket.receive(buf, 0, buf.length, MessageFlag.NONE);
+        return Bits.getInt(buf);
+    }
+
+    /**
+     * Send a 4-byte value as a frame of data on the given Socket.
+     * 
+     * @param socket The socket to send to
+     */
+    public void send(Socket socket) {
+        socket.send(buf);
+    }
+
+    /**
+     * Alias for {@link #setValue(int)}. Useful for method chaining.
+     * 
+     * @param val The integer value
+     * @return This object, with the value set
+     */
+    public ZInteger put(int val) {
+        setValue(val);
+        return this;
+    }
+
+    /**
+     * Set a value on the buffer.
+     * 
+     * @param val The integer value
+     */
+    public void setValue(int val) {
+        Bits.putInt(buf, val);
+    }
+
+    /**
+     * Construct a Frame from the data contained in this buffer.
+     * 
+     * @return A Frame containing the data in this buffer
+     */
+    public Frame frame() {
+        byte[] newbuf = new byte[4];
+        System.arraycopy(buf, 0, newbuf, 0, 4);
+        return new Frame(newbuf);
+    }
+
+    /**
+     * Returns the value of this buffer as an {@code int}.
+     * 
+     * @return  the numeric value represented by this object after conversion
+     *          to type {@code int}.
+     */
+    public int intValue() {
+        return Bits.getInt(buf);
+    }
+
+    /**
+     * Returns the value of this buffer as a {@code long}.
+     * 
+     * @return  the numeric value represented by this object after conversion
+     *          to type {@code long}.
+     */
+    public long longValue() {
+        return intValue();
+    }
+}

--- a/src/main/java/org/zeromq/api/ZLong.java
+++ b/src/main/java/org/zeromq/api/ZLong.java
@@ -1,0 +1,96 @@
+package org.zeromq.api;
+
+import org.zeromq.api.Message.Frame;
+
+/**
+ * Buffer capable of sending/receiving an 8-byte integer (Java {@code long}). 
+ */
+public class ZLong {
+    private final byte[] buf = new byte[8];
+
+    /**
+     * Construct an empty buffer (defaults to 0).
+     */
+    public ZLong() {
+    }
+
+    /**
+     * Construct a buffer with a default value.
+     * 
+     * @param val The default value
+     */
+    public ZLong(long val) {
+        setValue(val);
+    }
+
+    /**
+     * Receive an 8-byte value as a frame of data on the given Socket.
+     * 
+     * @param socket The Socket to read from
+     * @return The integer value received from the Socket
+     */
+    public long receive(Socket socket) {
+        socket.receive(buf, 0, buf.length, MessageFlag.NONE);
+        return longValue();
+    }
+
+    /**
+     * Send an 8-byte value as a frame of data on the given Socket.
+     * 
+     * @param socket The socket to send to
+     */
+    public void send(Socket socket) {
+        socket.send(buf);
+    }
+
+    /**
+     * Alias for {@link #setValue(long)}. Useful for method chaining.
+     * 
+     * @param val The long value
+     * @return This object, with the value set
+     */
+    public ZLong put(long val) {
+        setValue(val);
+        return this;
+    }
+
+    /**
+     * Set a value on the buffer.
+     * 
+     * @param val The long value
+     */
+    public void setValue(long val) {
+        Bits.putLong(buf, val);
+    }
+
+    /**
+     * Construct a Frame from the data contained in this buffer.
+     * 
+     * @return A Frame containing the data in this buffer
+     */
+    public Frame frame() {
+        byte[] newbuf = new byte[8];
+        System.arraycopy(buf, 0, newbuf, 0, 8);
+        return new Frame(newbuf);
+    }
+
+    /**
+     * Returns the value of this buffer as an {@code int}.
+     * 
+     * @return  the numeric value represented by this object after conversion
+     *          to type {@code int}.
+     */
+    public int intValue() {
+        return (int) longValue();
+    }
+
+    /**
+     * Returns the value of this buffer as a {@code long}.
+     * 
+     * @return  the numeric value represented by this object after conversion
+     *          to type {@code long}.
+     */
+    public long longValue() {
+        return Bits.getLong(buf);
+    }
+}

--- a/src/main/java/org/zeromq/api/exception/ContextTerminatedException.java
+++ b/src/main/java/org/zeromq/api/exception/ContextTerminatedException.java
@@ -24,7 +24,6 @@ public class ContextTerminatedException extends ZMQRuntimeException {
     /**
      * Constructor, with ZMQException cause.
      * 
-     * @param message The error message
      * @param cause The underlying cause
      */
     public ContextTerminatedException(ZMQException cause) {

--- a/src/main/java/org/zeromq/api/exception/InvalidSocketException.java
+++ b/src/main/java/org/zeromq/api/exception/InvalidSocketException.java
@@ -1,5 +1,6 @@
 package org.zeromq.api.exception;
 
+import org.zeromq.ZMQ;
 import org.zeromq.ZMQException;
 
 /**
@@ -24,10 +25,18 @@ public class InvalidSocketException extends ZMQRuntimeException {
     /**
      * Constructor, with ZMQException cause.
      * 
-     * @param message The error message
      * @param cause The underlying cause
      */
     public InvalidSocketException(ZMQException cause) {
         super(cause);
+    }
+
+    /**
+     * Constructor, with message.
+     * 
+     * @param message The error message
+     */
+    public InvalidSocketException(String message) {
+        super(message, (int) ZMQ.Error.ENOTSOCK.getCode());
     }
 }

--- a/src/main/java/org/zeromq/jzmq/ManagedContext.java
+++ b/src/main/java/org/zeromq/jzmq/ManagedContext.java
@@ -176,8 +176,13 @@ public class ManagedContext implements Context {
     }
 
     @Override
-    public void queue(Socket frontEnd, Socket backEnd) {
+    public void forward(Socket frontEnd, Socket backEnd) {
         new ProxyThread(this, frontEnd, backEnd).start();
+    }
+
+    @Override
+    public void queue(Socket frontEnd, Socket backEnd) {
+        forward(frontEnd, backEnd);
     }
 
     public void addBackgroundable(Backgroundable backgroundable) {

--- a/src/main/java/org/zeromq/jzmq/ManagedContext.java
+++ b/src/main/java/org/zeromq/jzmq/ManagedContext.java
@@ -20,8 +20,10 @@ import org.zeromq.api.PollerType;
 import org.zeromq.api.Socket;
 import org.zeromq.api.SocketType;
 import org.zeromq.api.exception.ZMQExceptions;
+import org.zeromq.jzmq.bstar.BinaryStarBuilder;
 import org.zeromq.jzmq.poll.PollableImpl;
 import org.zeromq.jzmq.poll.PollerBuilder;
+import org.zeromq.jzmq.reactor.ReactorBuilder;
 import org.zeromq.jzmq.sockets.DealerSocketBuilder;
 import org.zeromq.jzmq.sockets.PairSocketBuilder;
 import org.zeromq.jzmq.sockets.PubSocketBuilder;
@@ -186,6 +188,16 @@ public class ManagedContext implements Context {
     @Override
     public Pollable newPollable(Socket socket, PollerType... options) {
         return new PollableImpl(socket, options);
+    }
+
+    @Override
+    public ReactorBuilder buildReactor() {
+        return new ReactorBuilder(this);
+    }
+
+    @Override
+    public BinaryStarBuilder buildBinaryStar() {
+        return new BinaryStarBuilder(this);
     }
 
     @Override

--- a/src/main/java/org/zeromq/jzmq/ManagedContext.java
+++ b/src/main/java/org/zeromq/jzmq/ManagedContext.java
@@ -1,5 +1,6 @@
 package org.zeromq.jzmq;
 
+import java.nio.channels.SelectableChannel;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -15,12 +16,16 @@ import org.zeromq.ZMQ;
 import org.zeromq.ZMQException;
 import org.zeromq.api.Backgroundable;
 import org.zeromq.api.Context;
+import org.zeromq.api.DeviceType;
 import org.zeromq.api.Pollable;
 import org.zeromq.api.PollerType;
 import org.zeromq.api.Socket;
 import org.zeromq.api.SocketType;
 import org.zeromq.api.exception.ZMQExceptions;
+import org.zeromq.jzmq.beacon.BeaconReactorBuilder;
 import org.zeromq.jzmq.bstar.BinaryStarBuilder;
+import org.zeromq.jzmq.bstar.BinaryStarSocketBuilder;
+import org.zeromq.jzmq.device.DeviceBuilder;
 import org.zeromq.jzmq.poll.PollableImpl;
 import org.zeromq.jzmq.poll.PollerBuilder;
 import org.zeromq.jzmq.reactor.ReactorBuilder;
@@ -34,6 +39,8 @@ import org.zeromq.jzmq.sockets.ReqSocketBuilder;
 import org.zeromq.jzmq.sockets.RouterSocketBuilder;
 import org.zeromq.jzmq.sockets.SocketBuilder;
 import org.zeromq.jzmq.sockets.SubSocketBuilder;
+import org.zeromq.jzmq.sockets.XPubSocketBuilder;
+import org.zeromq.jzmq.sockets.XSubSocketBuilder;
 
 /**
  * Manage JZMQ Context
@@ -147,6 +154,10 @@ public class ManagedContext implements Context {
                 return new PubSocketBuilder(this);
             case SUB:
                 return new SubSocketBuilder(this);
+            case XPUB:
+                return new XPubSocketBuilder(this);
+            case XSUB:
+                return new XSubSocketBuilder(this);
             case REP:
                 return new RepSocketBuilder(this);
             case REQ:
@@ -191,6 +202,11 @@ public class ManagedContext implements Context {
     }
 
     @Override
+    public Pollable newPollable(SelectableChannel channel, PollerType... options) {
+        return new PollableImpl(channel, options);
+    }
+
+    @Override
     public ReactorBuilder buildReactor() {
         return new ReactorBuilder(this);
     }
@@ -198,6 +214,21 @@ public class ManagedContext implements Context {
     @Override
     public BinaryStarBuilder buildBinaryStar() {
         return new BinaryStarBuilder(this);
+    }
+
+    @Override
+    public BinaryStarSocketBuilder buildBinaryStarSocket() {
+        return new BinaryStarSocketBuilder(this);
+    }
+
+    @Override
+    public BeaconReactorBuilder buildBeaconReactor() {
+        return new BeaconReactorBuilder(this);
+    }
+
+    @Override
+    public DeviceBuilder buildDevice(DeviceType deviceType) {
+        return new DeviceBuilder(this, deviceType);
     }
 
     @Override
@@ -267,7 +298,6 @@ public class ManagedContext implements Context {
                     throw ZMQExceptions.wrap(ex);
                 }
             }
-            context.close();
             log.debug("Background thread {} has shut down", Thread.currentThread().getName());
         }
     }

--- a/src/main/java/org/zeromq/jzmq/ManagedContext.java
+++ b/src/main/java/org/zeromq/jzmq/ManagedContext.java
@@ -82,7 +82,7 @@ public class ManagedContext implements Context {
     public void destroySocket(Socket socket) {
         if (sockets.contains(socket)) {
             try {
-                socket.getZMQSocket().close();
+                socket.close();
             } catch (Exception ignore) {
                 log.warn("Exception caught while closing underlying socket.", ignore);
             }

--- a/src/main/java/org/zeromq/jzmq/ManagedContext.java
+++ b/src/main/java/org/zeromq/jzmq/ManagedContext.java
@@ -232,6 +232,7 @@ public class ManagedContext implements Context {
                     throw ZMQExceptions.wrap(ex);
                 }
             }
+            context.close();
             log.debug("Background thread {} has shut down", Thread.currentThread().getName());
         }
     }

--- a/src/main/java/org/zeromq/jzmq/ManagedContext.java
+++ b/src/main/java/org/zeromq/jzmq/ManagedContext.java
@@ -212,7 +212,7 @@ public class ManagedContext implements Context {
     }
 
     @Override
-    public BinaryStarBuilder buildBinaryStar() {
+    public BinaryStarBuilder buildBinaryStarReactor() {
         return new BinaryStarBuilder(this);
     }
 

--- a/src/main/java/org/zeromq/jzmq/ManagedSocket.java
+++ b/src/main/java/org/zeromq/jzmq/ManagedSocket.java
@@ -91,12 +91,16 @@ public class ManagedSocket implements Socket {
         }
     }
 
-
     @Override
     public Message receiveMessage() {
+        return receiveMessage(MessageFlag.NONE);
+    }
+
+    @Override
+    public Message receiveMessage(MessageFlag flag) {
         Message message = null;
         try {
-            message = fillInFrames(new Message());
+            message = fillInFrames(new Message(), flag);
         } catch (ContextTerminatedException | InvalidSocketException ignored) {
         }
         return message;
@@ -104,22 +108,27 @@ public class ManagedSocket implements Socket {
 
     @Override
     public RoutedMessage receiveRoutedMessage() {
+        return receiveRoutedMessage(MessageFlag.NONE);
+    }
+
+    @Override
+    public RoutedMessage receiveRoutedMessage(MessageFlag flag) {
         RoutedMessage message = null;
         try {
-            message = fillInFrames(new RoutedMessage());
+            message = fillInFrames(new RoutedMessage(), flag);
         } catch (ContextTerminatedException | InvalidSocketException ignored) {
         }
         return message;
     }
 
-    private <T extends Message> T fillInFrames(T message) {
-        byte[] bytes = receive();
+    private <T extends Message> T fillInFrames(T message, MessageFlag flag) {
+        byte[] bytes = receive(flag);
         if (bytes == null) {
             return null;
         }
         message.addFrame(new Frame(bytes));
         while (hasMoreToReceive()) {
-            byte[] data = receive();
+            byte[] data = receive(flag);
             message.addFrame(new Frame(data));
         }
         return message;

--- a/src/main/java/org/zeromq/jzmq/UdpSocket.java
+++ b/src/main/java/org/zeromq/jzmq/UdpSocket.java
@@ -1,0 +1,196 @@
+package org.zeromq.jzmq;
+
+import java.io.IOException;
+import java.net.DatagramSocket;
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.NetworkInterface;
+import java.net.SocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.DatagramChannel;
+import java.util.Collections;
+import java.util.Enumeration;
+
+/**
+ * Socket for sending UDP messages.
+ * <p>
+ * This class was adapted from <code>ZreUdp</code> in the
+ *   <a href="https://github.com/zeromq/jyre/blob/master/src/main/java/org/zyre/ZreUdp.java">Jyre</a>
+ * project.
+ */
+public class UdpSocket {
+    private static final byte[] BIND_ADDRESS = new byte[] {0, 0, 0, 0};
+    private static final String BROADCAST_HOST = "255.255.255.255";
+
+    private DatagramChannel handle;     // Channel for send/recv
+    private DatagramSocket socket;      // Socket for send/recv
+    private int port;                   // UDP port number we work on
+    private InetAddress address;        // Own address
+    private SocketAddress broadcast;    // Broadcast address
+    private SocketAddress sender;       // Where last recv came from
+    private String host;                // Our own address as string
+    private String from;                // Sender address of last message
+
+    /**
+     * Constructor.
+     *
+     * @param port The local port to bind to
+     */
+    public UdpSocket(int port) throws IOException {
+        this.port = port;
+
+        initialize();
+    }
+
+    private void initialize() throws IOException {
+        // Create UDP socket
+        this.handle = DatagramChannel.open();
+        this.socket = handle.socket();
+        this.broadcast = new InetSocketAddress(InetAddress.getByName(BROADCAST_HOST), port);
+
+        // Configure as non-blocking
+        handle.configureBlocking(false);
+
+        // Ask operating system to let us do broadcasts from socket
+        socket.setBroadcast(true);
+
+        // Allow multiple processes to bind to socket; incoming
+        // messages will come to each process
+        socket.setReuseAddress(true);
+
+        // Find the applicable local address
+        Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
+        for (NetworkInterface networkInterface : Collections.list(interfaces)) {
+            if (networkInterface.isLoopback()) {
+                continue;
+            }
+
+            Enumeration<InetAddress> addresses = networkInterface.getInetAddresses();
+            for (InetAddress address : Collections.list(addresses)) {
+                if (address instanceof Inet4Address) {
+                    this.address = address;
+                    this.host = address.getHostAddress();
+                    break;
+                }
+            }
+        }
+
+        socket.bind(new InetSocketAddress(InetAddress.getByAddress(BIND_ADDRESS), port));
+    }
+
+    /**
+     * Close the socket.
+     */
+    public void close() {
+        try {
+            handle.close();
+        } catch (IOException ignored) {
+        }
+    }
+
+    /**
+     * Return the UDP channel.
+     *
+     * @return The UDP channel
+     */
+    public DatagramChannel getChannel() {
+        return handle;
+    }
+
+    /**
+     * Return the UDP socket.
+     * 
+     * @return The UDP socket
+     */
+    public DatagramSocket getSocket() {
+        return socket;
+    }
+
+    /**
+     * Return our own SocketAddress.
+     * 
+     * @return Our own address
+     */
+    public InetAddress getAddress() {
+        return address;
+    }
+
+    /**
+     * Return our own IP address as printable string.
+     *
+     * @return Our own IP address
+     */
+    public String getHost() {
+        return host;
+    }
+
+    /**
+     * Return the UDP socket port.
+     *
+     * @return The UDP socket port
+     */
+    public int getPort() {
+        return port;
+    }
+
+    /**
+     * Return the SocketAddress of the peer that sent last message.
+     * 
+     * @return The address of last peer
+     */
+    public SocketAddress getSender() {
+        return sender;
+    }
+
+    /**
+     * Return the IP address of peer that sent last message.
+     *
+     * @return The IP address of last peer
+     */
+    public String getFrom() {
+        return from;
+    }
+
+    /**
+     * Send a message using UDP broadcast.
+     *
+     * @param buffer The message as a byte buffer
+     * @throws IOException If an error occurs sending the message
+     */
+    public void send(ByteBuffer buffer) throws IOException {
+        handle.send(buffer, broadcast);
+    }
+
+    /**
+     * Send a message using UDP.
+     * 
+     * @param buffer The message as a byte buffer
+     * @param address The host name or address of the server
+     * @throws IOException If an error occurs sending the message
+     */
+    public void send(ByteBuffer buffer, String address) throws IOException {
+        SocketAddress socketAddress = new InetSocketAddress(InetAddress.getByName(address), port);
+        handle.send(buffer, socketAddress);
+    }
+
+    /**
+     * Receive a message from UDP broadcast.
+     *
+     * @param buffer The buffer to place received data into
+     * @return The size of received message, or -1
+     * @throws IOException If an error occurs receiving the message
+     */
+    public int receive(ByteBuffer buffer) throws IOException {
+        int read = -1;
+        int remaining = buffer.remaining();
+
+        sender = handle.receive(buffer);
+        if (sender != null) {
+            from = ((InetSocketAddress) sender).getAddress().getHostAddress();
+            read = remaining - buffer.remaining();
+        }
+
+        return read;
+    }
+}

--- a/src/main/java/org/zeromq/jzmq/beacon/BeaconReactorBuilder.java
+++ b/src/main/java/org/zeromq/jzmq/beacon/BeaconReactorBuilder.java
@@ -1,0 +1,70 @@
+package org.zeromq.jzmq.beacon;
+
+import org.zeromq.api.BeaconListener;
+import org.zeromq.api.BeaconReactor;
+import org.zeromq.api.UdpBeacon;
+import org.zeromq.jzmq.ManagedContext;
+
+import java.io.IOException;
+
+public class BeaconReactorBuilder {
+    public static class Spec {
+        public UdpBeacon beacon;
+        public int port;
+        public BeaconListener listener;
+        public long broadcastInterval;
+        public boolean ignoreLocalAddress = true;
+    }
+
+    private final ManagedContext context;
+    private final Spec spec = new Spec();
+
+    public BeaconReactorBuilder(ManagedContext context) {
+        this.context = context;
+    }
+
+    public BeaconReactorBuilder withBeacon(UdpBeacon beacon) {
+        spec.beacon = beacon;
+        return this;
+    }
+
+    public BeaconReactorBuilder withPort(int port) {
+        spec.port = port;
+        return this;
+    }
+
+    public BeaconReactorBuilder withListener(BeaconListener listener) {
+        spec.listener = listener;
+        return this;
+    }
+
+    public BeaconReactorBuilder withBroadcastInterval(long broadcastInterval) {
+        spec.broadcastInterval = broadcastInterval;
+        return this;
+    }
+
+    public BeaconReactorBuilder withIgnoreLocalAddress(boolean ignoreLocalAddress) {
+        spec.ignoreLocalAddress = ignoreLocalAddress;
+        return this;
+    }
+
+    public BeaconReactor build() throws IOException {
+        assert (spec.listener != null);
+
+        BeaconReactorImpl reactor = new BeaconReactorImpl(context, spec.port, spec.beacon);
+        reactor.setIgnoreLocalAddress(spec.ignoreLocalAddress);
+        reactor.setListener(spec.listener);
+        if (spec.broadcastInterval != 0) {
+            reactor.setBroadcastInterval(spec.broadcastInterval);
+        }
+
+        return reactor;
+    }
+
+    public BeaconReactor start() throws IOException {
+        BeaconReactor reactor = build();
+        reactor.start();
+
+        return reactor;
+    }
+}

--- a/src/main/java/org/zeromq/jzmq/beacon/BeaconReactorImpl.java
+++ b/src/main/java/org/zeromq/jzmq/beacon/BeaconReactorImpl.java
@@ -1,0 +1,110 @@
+package org.zeromq.jzmq.beacon;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.zeromq.api.BeaconListener;
+import org.zeromq.api.BeaconReactor;
+import org.zeromq.api.LoopHandler;
+import org.zeromq.api.Pollable;
+import org.zeromq.api.PollerType;
+import org.zeromq.api.Reactor;
+import org.zeromq.api.UdpBeacon;
+import org.zeromq.jzmq.ManagedContext;
+import org.zeromq.jzmq.UdpSocket;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+
+public class BeaconReactorImpl implements BeaconReactor {
+    private static final Logger log = LoggerFactory.getLogger(BeaconReactorImpl.class);
+    private static final long DEFAULT_BROADCAST_INTERVAL = 1000L;
+
+    private final ManagedContext context;
+    private final Reactor reactor;
+    private final UdpSocket socket;
+    private final UdpBeacon beacon;
+    private BeaconListener listener;
+    private long broadcastInterval = DEFAULT_BROADCAST_INTERVAL;
+    private boolean ignoreLocalAddress = false;
+
+    public BeaconReactorImpl(ManagedContext context, int broadcastPort, UdpBeacon beacon) throws IOException {
+        this.context = context;
+        this.beacon = beacon;
+        this.socket = new UdpSocket(broadcastPort);
+        this.reactor = context.buildReactor()
+            .build();
+    }
+
+    @Override
+    public void start() {
+        assert (listener != null);
+        reactor.addTimer(broadcastInterval, -1, SEND_BEACON);
+        reactor.addPollable(context.newPollable(socket.getChannel(), PollerType.POLL_IN), RECEIVE_BEACON);
+        reactor.start();
+    }
+
+    @Override
+    public void stop() {
+        reactor.stop();
+    }
+
+    public void setListener(BeaconListener listener) {
+        this.listener = listener;
+    }
+
+    public void setBroadcastInterval(long broadcastInterval) {
+        this.broadcastInterval = broadcastInterval;
+    }
+
+    public void setIgnoreLocalAddress(boolean ignoreLocalAddress) {
+        this.ignoreLocalAddress = ignoreLocalAddress;
+    }
+
+    private final LoopHandler SEND_BEACON = new LoopHandler() {
+        @Override
+        public void execute(Reactor reactor, Pollable pollable, Object... args) {
+            try {
+                socket.send(beacon.getBuffer());
+            } catch (IOException ex) {
+                log.error("Unable to send UDP beacon:", ex);
+            }
+        }
+    };
+
+    private final LoopHandler RECEIVE_BEACON = new LoopHandler() {
+        private ByteBuffer buffer = ByteBuffer.allocate(Short.MAX_VALUE);
+
+        @Override
+        public void execute(Reactor reactor, Pollable pollable, Object... args) {
+            try {
+                int read = socket.receive(buffer);
+                buffer.rewind();
+                if (socket.getSender() == null
+                        || read < UdpBeacon.BEACON_SIZE) {
+                    return;
+                }
+
+                InetAddress sender = ((InetSocketAddress) socket.getSender()).getAddress();
+                if (ignoreLocalAddress &&
+                        (InetAddress.getLocalHost().getHostAddress().equals(sender.getHostAddress())
+                        || sender.isAnyLocalAddress()
+                        || sender.isLoopbackAddress())) {
+                    return;
+                }
+
+                UdpBeacon message = new UdpBeacon(buffer);
+                buffer.rewind();
+                if (!beacon.getProtocol().equals(message.getProtocol())
+                        || beacon.getVersion() != message.getVersion()) {
+                    return;
+                }
+
+                listener.onBeacon(sender, message);
+            } catch (IOException ex) {
+                log.error("Unable to receive UDP beacon:", ex);
+            }
+        }
+    };
+}

--- a/src/main/java/org/zeromq/jzmq/bstar/BinaryStarBuilder.java
+++ b/src/main/java/org/zeromq/jzmq/bstar/BinaryStarBuilder.java
@@ -12,6 +12,7 @@ public class BinaryStarBuilder {
         public Mode mode;
         public String local;
         public String remote;
+        public long heartbeatInterval = BinaryStar.BSTAR_HEARTBEAT;
         public Socket voter;
 
         public LoopHandler activeHandler;
@@ -47,14 +48,18 @@ public class BinaryStarBuilder {
         return this;
     }
 
+    public BinaryStarBuilder withHeartbeatInterval(long heartbeatInterval) {
+        spec.heartbeatInterval = heartbeatInterval;
+        return this;
+    }
+
     public BinaryStarBuilder withVoterSocket(Socket voter) {
         spec.voter = voter;
         return this;
     }
 
     public BinaryStarBuilder withVoterSocket(String url) {
-        Socket socket = context.buildSocket(SocketType.SUB)
-            .asSubscribable().subscribeAll()
+        Socket socket = context.buildSocket(SocketType.ROUTER)
             .bind(url);
 
         return withVoterSocket(socket);
@@ -87,6 +92,7 @@ public class BinaryStarBuilder {
         binaryStar.setVoterHandler(spec.voterHandler, spec.voterArgs);
         binaryStar.setActiveHandler(spec.activeHandler, spec.activeArgs);
         binaryStar.setPassiveHandler(spec.passiveHandler, spec.passiveArgs);
+        binaryStar.setHeartbeatInterval(spec.heartbeatInterval);
 
         return binaryStar;
     }

--- a/src/main/java/org/zeromq/jzmq/bstar/BinaryStarBuilder.java
+++ b/src/main/java/org/zeromq/jzmq/bstar/BinaryStarBuilder.java
@@ -1,0 +1,101 @@
+package org.zeromq.jzmq.bstar;
+
+import org.zeromq.ZMQ;
+import org.zeromq.api.BinaryStar;
+import org.zeromq.api.BinaryStar.Mode;
+import org.zeromq.api.LoopHandler;
+import org.zeromq.api.Socket;
+import org.zeromq.api.SocketType;
+import org.zeromq.jzmq.ManagedContext;
+
+public class BinaryStarBuilder {
+    public class Spec {
+        public Mode mode;
+        public String local;
+        public String remote;
+        public Socket voter;
+
+        public LoopHandler activeHandler;
+        public Object[] activeArgs;
+
+        public LoopHandler voterHandler;
+        public Object[] voterArgs;
+
+        public LoopHandler passiveHandler;
+        public Object[] passiveArgs;
+    }
+
+    private ManagedContext context;
+    private Spec spec;
+
+    public BinaryStarBuilder(ManagedContext context) {
+        this.context = context;
+        this.spec = new Spec();
+    }
+
+    public BinaryStarBuilder withMode(Mode mode) {
+        spec.mode = mode;
+        return this;
+    }
+
+    public BinaryStarBuilder withLocalUrl(String local) {
+        spec.local = local;
+        return this;
+    }
+
+    public BinaryStarBuilder withRemoteUrl(String remote) {
+        spec.remote = remote;
+        return this;
+    }
+
+    public BinaryStarBuilder withVoterSocket(Socket voter) {
+        spec.voter = voter;
+        return this;
+    }
+
+    public BinaryStarBuilder withVoterSocket(String url) {
+        Socket socket = context.buildSocket(SocketType.SUB)
+            .asSubscribable().subscribe(ZMQ.SUBSCRIPTION_ALL)
+            .bind(url);
+
+        return withVoterSocket(socket);
+    }
+
+    public BinaryStarBuilder withActiveHandler(LoopHandler activeHandler, Object... activeArgs) {
+        spec.activeHandler = activeHandler;
+        spec.activeArgs = activeArgs;
+        return this;
+    }
+
+    public BinaryStarBuilder withVoterHandler(LoopHandler voterHandler, Object... voterArgs) {
+        spec.voterHandler = voterHandler;
+        spec.voterArgs = voterArgs;
+        return this;
+    }
+
+    public BinaryStarBuilder withPassiveHandler(LoopHandler passiveHandler, Object... passiveArgs) {
+        spec.passiveHandler = passiveHandler;
+        spec.passiveArgs = passiveArgs;
+        return this;
+    }
+
+    public BinaryStar build() {
+        assert (spec.voter != null);
+        assert (spec.voterHandler != null);
+
+        BinaryStar binaryStar = new BinaryStarImpl(context, spec.mode, spec.local, spec.remote);
+        binaryStar.registerVoterSocket(spec.voter);
+        binaryStar.setVoterHandler(spec.voterHandler, spec.voterArgs);
+        binaryStar.setActiveHandler(spec.activeHandler, spec.activeArgs);
+        binaryStar.setPassiveHandler(spec.passiveHandler, spec.passiveArgs);
+
+        return binaryStar;
+    }
+
+    public BinaryStar start() {
+        BinaryStar binaryStar = build();
+        binaryStar.start();
+
+        return binaryStar;
+    }
+}

--- a/src/main/java/org/zeromq/jzmq/bstar/BinaryStarBuilder.java
+++ b/src/main/java/org/zeromq/jzmq/bstar/BinaryStarBuilder.java
@@ -1,7 +1,7 @@
 package org.zeromq.jzmq.bstar;
 
-import org.zeromq.api.BinaryStar;
-import org.zeromq.api.BinaryStar.Mode;
+import org.zeromq.api.BinaryStarReactor;
+import org.zeromq.api.BinaryStarReactor.Mode;
 import org.zeromq.api.LoopHandler;
 import org.zeromq.api.Socket;
 import org.zeromq.api.SocketType;
@@ -12,7 +12,7 @@ public class BinaryStarBuilder {
         public Mode mode;
         public String local;
         public String remote;
-        public long heartbeatInterval = BinaryStar.BSTAR_HEARTBEAT;
+        public long heartbeatInterval = BinaryStarReactor.BSTAR_HEARTBEAT;
         public Socket voter;
 
         public LoopHandler activeHandler;
@@ -83,24 +83,24 @@ public class BinaryStarBuilder {
         return this;
     }
 
-    public BinaryStar build() {
+    public BinaryStarReactor build() {
         assert (spec.voter != null);
         assert (spec.voterHandler != null);
 
-        BinaryStar binaryStar = new BinaryStarImpl(context, spec.mode, spec.local, spec.remote);
-        binaryStar.registerVoterSocket(spec.voter);
-        binaryStar.setVoterHandler(spec.voterHandler, spec.voterArgs);
-        binaryStar.setActiveHandler(spec.activeHandler, spec.activeArgs);
-        binaryStar.setPassiveHandler(spec.passiveHandler, spec.passiveArgs);
-        binaryStar.setHeartbeatInterval(spec.heartbeatInterval);
+        BinaryStarReactor reactor = new BinaryStarReactorImpl(context, spec.mode, spec.local, spec.remote);
+        reactor.registerVoterSocket(spec.voter);
+        reactor.setVoterHandler(spec.voterHandler, spec.voterArgs);
+        reactor.setActiveHandler(spec.activeHandler, spec.activeArgs);
+        reactor.setPassiveHandler(spec.passiveHandler, spec.passiveArgs);
+        reactor.setHeartbeatInterval(spec.heartbeatInterval);
 
-        return binaryStar;
+        return reactor;
     }
 
-    public BinaryStar start() {
-        BinaryStar binaryStar = build();
-        binaryStar.start();
+    public BinaryStarReactor start() {
+        BinaryStarReactor reactor = build();
+        reactor.start();
 
-        return binaryStar;
+        return reactor;
     }
 }

--- a/src/main/java/org/zeromq/jzmq/bstar/BinaryStarBuilder.java
+++ b/src/main/java/org/zeromq/jzmq/bstar/BinaryStarBuilder.java
@@ -1,6 +1,5 @@
 package org.zeromq.jzmq.bstar;
 
-import org.zeromq.ZMQ;
 import org.zeromq.api.BinaryStar;
 import org.zeromq.api.BinaryStar.Mode;
 import org.zeromq.api.LoopHandler;
@@ -55,7 +54,7 @@ public class BinaryStarBuilder {
 
     public BinaryStarBuilder withVoterSocket(String url) {
         Socket socket = context.buildSocket(SocketType.SUB)
-            .asSubscribable().subscribe(ZMQ.SUBSCRIPTION_ALL)
+            .asSubscribable().subscribeAll()
             .bind(url);
 
         return withVoterSocket(socket);

--- a/src/main/java/org/zeromq/jzmq/bstar/BinaryStarClient.java
+++ b/src/main/java/org/zeromq/jzmq/bstar/BinaryStarClient.java
@@ -1,0 +1,114 @@
+package org.zeromq.jzmq.bstar;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.zeromq.api.Backgroundable;
+import org.zeromq.api.Context;
+import org.zeromq.api.Message;
+import org.zeromq.api.MessageFlag;
+import org.zeromq.api.PollAdapter;
+import org.zeromq.api.Poller;
+import org.zeromq.api.Socket;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+class BinaryStarClient implements Backgroundable {
+    private final Logger log = LoggerFactory.getLogger(BinaryStarClient.class);
+
+    /**
+     * States we can be in at any point in time.
+     */
+    private enum State {
+        CONNECTING,
+        ACTIVE,
+        FORWARDING
+    }
+
+    private BinaryStarSocketBuilder socketBuilder;
+    private String url1;
+    private String url2;
+    private long heartbeatInterval;
+    private AtomicBoolean closed = new AtomicBoolean(false);
+
+    public BinaryStarClient(BinaryStarSocketBuilder socketBuilder, String url1, String url2, long heartbeatInterval) {
+        this.socketBuilder = socketBuilder;
+        this.url1 = url1;
+        this.url2 = url2;
+        this.heartbeatInterval = heartbeatInterval;
+    }
+
+    @Override
+    public void run(Context context, Socket pipe, Object... args) {
+        Socket socket = null;
+        Message message = null;
+        Poller poller = null;
+
+        boolean primary = true;
+        State state = State.CONNECTING;
+        while (!closed.get()) {
+            if (state == State.CONNECTING) {
+                if (socket != null) {
+                    // Old socket is confused; close it and open a new one
+                    poller.disable(socket);
+                    socket.close();
+                    primary = !primary;
+                }
+
+                socket = createSocket(primary);
+                poller = context.buildPoller()
+                    .withInPollable(pipe, new PollAdapter())
+                    .withInPollable(socket, new PollAdapter())
+                    .build();
+
+                if (message != null) {
+                    // Send request again, on new socket
+                    state = State.FORWARDING;
+                } else {
+                    state = State.ACTIVE;
+                }
+            } else if (state == State.FORWARDING) {
+                // We send a request, then we work to get a reply
+                socket.send(message);
+
+                // Poll socket for a reply, with timeout
+                poller.poll(heartbeatInterval * 2);
+
+                // We use a Lazy Pirate strategy in the client. If there's no
+                // reply within our timeout, we close the socket and try again.
+                // In Binary Star, it's the client vote that decides which
+                // server is primary; the client must therefore try to connect
+                // to each server in turn:
+
+                Message reply = socket.receiveMessage(MessageFlag.DONT_WAIT);
+                if (reply != null) {
+                    // We got a reply from the server
+                    log.debug("Server replied OK");
+                    pipe.send(reply);
+                    message = null;
+
+                    state = State.ACTIVE;
+                } else {
+                    log.warn("No response from server, failing over");
+                    state = State.CONNECTING;
+                }
+            } else {
+                // Wait for a message from client socket
+                poller.poll();
+                message = pipe.receiveMessage();
+
+                state = State.FORWARDING;
+            }
+        }
+    }
+
+    private Socket createSocket(boolean primary) {
+        String url = primary ? url1 : url2;
+        log.info("Connecting to server at {}", url);
+        return socketBuilder.connect(primary ? url1 : url2);
+    }
+
+    @Override
+    public void onClose() {
+        closed.set(true);
+    }
+}

--- a/src/main/java/org/zeromq/jzmq/bstar/BinaryStarImpl.java
+++ b/src/main/java/org/zeromq/jzmq/bstar/BinaryStarImpl.java
@@ -4,6 +4,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.zeromq.api.BinaryStar;
 import org.zeromq.api.LoopHandler;
+import org.zeromq.api.Pollable;
 import org.zeromq.api.PollerType;
 import org.zeromq.api.Reactor;
 import org.zeromq.api.Socket;
@@ -14,11 +15,6 @@ import org.zeromq.jzmq.ManagedContext;
 public class BinaryStarImpl implements BinaryStar {
     private static final Logger log = LoggerFactory.getLogger(BinaryStarImpl.class);
 
-    /**
-     * We send state information this often. If peer doesn't respond in two heartbeats, it is 'dead'.
-     */
-    private static final long BSTAR_HEARTBEAT = 1000;
-
     private final ManagedContext context;
     private final Reactor reactor;
     private final Socket statePub;
@@ -28,6 +24,7 @@ public class BinaryStarImpl implements BinaryStar {
     private final Mode mode;
     private State state;
     private long peerExpiry;
+    private long heartbeatInterval;
 
     private LoopHandler activeHandler;
     private Object[] activeArgs;
@@ -66,8 +63,6 @@ public class BinaryStarImpl implements BinaryStar {
 
         // Set-up basic reactor events
         this.reactor = context.buildReactor()
-            .withTimerRepeating(BSTAR_HEARTBEAT, SEND_STATE, this)
-            .withInPollable(stateSub, RECEIVE_STATE, this)
             .build();
     }
 
@@ -79,6 +74,8 @@ public class BinaryStarImpl implements BinaryStar {
         assert (voterHandler != null);
 
         updatePeerExpiry();
+        reactor.addTimer(heartbeatInterval, -1, SEND_STATE, this);
+        reactor.addPollable(context.newPollable(stateSub, PollerType.POLL_IN), RECEIVE_STATE, this);
         reactor.start();
     }
 
@@ -151,8 +148,18 @@ public class BinaryStarImpl implements BinaryStar {
         return reactor;
     }
 
+    /**
+     * Set the heartbeat interval used to detect peer outage.
+     *
+     * @param heartbeatInterval The heartbeat interval, in milliseconds
+     */
+    @Override
+    public void setHeartbeatInterval(long heartbeatInterval) {
+        this.heartbeatInterval = heartbeatInterval;
+    }
+
     private void updatePeerExpiry() {
-        peerExpiry = System.currentTimeMillis() + BSTAR_HEARTBEAT * 2;
+        peerExpiry = System.currentTimeMillis() + heartbeatInterval * 2;
     }
 
     private void fireHandler(LoopHandler handler, Object... args) {
@@ -292,7 +299,7 @@ public class BinaryStarImpl implements BinaryStar {
      */
     private final LoopHandler SEND_STATE = new LoopHandler() {
         @Override
-        public void execute(Reactor reactor, Socket socket, Object... args) {
+        public void execute(Reactor reactor, Pollable pollable, Object... args) {
             stateBuf.put(state.ordinal()).send(statePub);
         }
     };
@@ -302,7 +309,7 @@ public class BinaryStarImpl implements BinaryStar {
      */
     private final LoopHandler RECEIVE_STATE = new LoopHandler() {
         @Override
-        public void execute(Reactor reactor, Socket socket, Object... args) {
+        public void execute(Reactor reactor, Pollable pollable, Object... args) {
             int ordinal = stateBuf.receive(stateSub);
             assert (ordinal >= 0 && ordinal < Event.values().length);
             updatePeerExpiry();
@@ -322,13 +329,13 @@ public class BinaryStarImpl implements BinaryStar {
      */
     private final LoopHandler VOTER_READY = new LoopHandler() {
         @Override
-        public void execute(Reactor reactor, Socket socket, Object... args) {
+        public void execute(Reactor reactor, Pollable pollable, Object... args) {
             // If server can accept input now, call applicable handler
             if (handleEvent(Event.CLIENT_REQUEST)) {
-                voterHandler.execute(reactor, socket, voterArgs);
+                voterHandler.execute(reactor, pollable, voterArgs);
             } else {
                 // Destroy waiting message, no-one to read it
-                socket.receiveMessage();
+                pollable.getSocket().receiveMessage();
             }
         }
     };

--- a/src/main/java/org/zeromq/jzmq/bstar/BinaryStarImpl.java
+++ b/src/main/java/org/zeromq/jzmq/bstar/BinaryStarImpl.java
@@ -1,0 +1,329 @@
+package org.zeromq.jzmq.bstar;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.zeromq.ZMQ;
+import org.zeromq.api.BinaryStar;
+import org.zeromq.api.LoopHandler;
+import org.zeromq.api.PollerType;
+import org.zeromq.api.Reactor;
+import org.zeromq.api.Socket;
+import org.zeromq.api.SocketType;
+import org.zeromq.api.ZInteger;
+import org.zeromq.jzmq.ManagedContext;
+import org.zeromq.jzmq.sockets.SocketBuilder;
+
+public class BinaryStarImpl implements BinaryStar {
+    private static final Logger log = LoggerFactory.getLogger(BinaryStarImpl.class);
+
+    /**
+     * We send state information this often. If peer doesn't respond in two heartbeats, it is 'dead'.
+     */
+    private static final long BSTAR_HEARTBEAT = 1000;
+
+    private final ManagedContext context;
+    private final Reactor reactor;
+    private final Socket statePub;
+    private final Socket stateSub;
+    private final ZInteger stateBuf = new ZInteger();
+
+    private final Mode mode;
+    private State state;
+    private long peerExpiry;
+
+    private LoopHandler activeHandler;
+    private Object[] activeArgs;
+
+    private LoopHandler voterHandler;
+    private Object[] voterArgs;
+
+    private LoopHandler passiveHandler;
+    private Object[] passiveArgs;
+
+    /**
+     * This is the constructor for our {@link BinaryStarImpl} class. We have to tell it
+     * whether we're primary or backup server, as well as our local and
+     * remote endpoints to bind and connect to.
+     * 
+     * @param mode The connection mode, either primary or backup
+     * @param local The local socket endpoint for publishing events
+     * @param remote The remote socket endpoint for subscribing to events
+     */
+    public BinaryStarImpl(ManagedContext context, Mode mode, String local, String remote) {
+        // Initialize the Binary Star
+        this.context = context;
+        this.mode = mode;
+        this.state = (mode == Mode.PRIMARY)
+            ? State.PRIMARY_CONNECTING
+            : State.BACKUP_CONNECTING;
+
+        // Create publisher for state going to peer
+        this.statePub = context.buildSocket(SocketType.PUB)
+            .bind(local);
+
+        // Create subscriber for state coming from peer
+        this.stateSub = context.buildSocket(SocketType.SUB)
+            .asSubscribable().subscribe(ZMQ.SUBSCRIPTION_ALL)
+            .connect(remote);
+
+        // Set-up basic reactor events
+        this.reactor = context.buildReactor()
+            .withTimerRepeating(BSTAR_HEARTBEAT, SEND_STATE, this)
+            .withInPollable(stateSub, RECEIVE_STATE, this)
+            .build();
+    }
+
+    /**
+     * Start the configured reactor.
+     */
+    @Override
+    public void start() {
+        assert (voterHandler != null);
+
+        updatePeerExpiry();
+        reactor.start();
+    }
+
+    /**
+     * This method registers a client voter socket. Messages received
+     * on this socket provide the CLIENT_REQUEST events for the Binary Star
+     * FSM and are passed to the provided application handler. We require
+     * exactly one voter per {@link BinaryStarImpl} instance.
+     *
+     * @param socket The client socket
+     */
+    @Override
+    public void registerVoterSocket(Socket socket) {
+        log.debug("Registering voter socket");
+        reactor.addPollable(context.newPollable(socket, PollerType.POLL_IN), VOTER_READY, this);
+    }
+
+    /**
+     * Register handlers to be called each time there's a state change.
+     * 
+     * @param handler The handler for client events
+     * @param args Arguments passed to the handler
+     */
+    @Override
+    public void setVoterHandler(LoopHandler handler, Object... args) {
+        this.voterHandler = handler;
+        this.voterArgs = args;
+    }
+
+    /**
+     * Register handlers to be called each time there's a state change.
+     *
+     * @param handler The handler for state change events
+     * @param args Arguments passed to the handler
+     */
+    @Override
+    public void setActiveHandler(LoopHandler handler, Object... args) {
+        this.activeHandler = handler;
+        this.activeArgs = args;
+    }
+
+    /**
+     * Register handlers to be called each time there's a state change.
+     *
+     * @param handler The handler for state change events
+     * @param args Arguments passed to the handler
+     */
+    @Override
+    public void setPassiveHandler(LoopHandler handler, Object... args) {
+        this.passiveHandler = handler;
+        this.passiveArgs = args;
+    }
+
+    /**
+     * This method returns the underlying Reactor, so we can add
+     * additional timers and readers.
+     * 
+     * @return The underlying Reactor
+     */
+    @Override
+    public Reactor getReactor() {
+        return reactor;
+    }
+
+    private void updatePeerExpiry() {
+        peerExpiry = System.currentTimeMillis() + BSTAR_HEARTBEAT * 2;
+    }
+
+    private void fireHandler(LoopHandler handler, Object... args) {
+        if (handler != null) {
+            handler.execute(reactor, null, args);
+        }
+    }
+
+    private boolean handleEvent(Event event) {
+        /*
+         * Binary Star finite state machine (applies event to state).
+         * Returns false if there was an exception, true if event was valid.
+         */
+        boolean result = true;
+
+        if (state == State.PRIMARY_CONNECTING) {
+             /*
+              * Primary server is waiting for peer to connect.
+              * Accepts CLIENT_REQUEST events in this state.
+              */
+            if (event == Event.PEER_BACKUP) {
+                log.info("Connected to backup (passive), ready as active");
+                state = State.ACTIVE;
+
+                fireHandler(activeHandler, activeArgs);
+            } else if (event == Event.PEER_ACTIVE) {
+                log.info("Connected to backup (active), ready as passive");
+                state = State.PASSIVE;
+
+                fireHandler(passiveHandler, passiveArgs);
+            } else if (event == Event.CLIENT_REQUEST) {
+                 /*
+                  * Allow client requests to turn us into the active if we've
+                  * waited sufficiently long to believe the backup is not
+                  * currently acting as active (i.e., after a failover).
+                  */
+                assert (peerExpiry > 0);
+                if (System.currentTimeMillis() >= peerExpiry) {
+                    log.info("Request from client, ready as active");
+                    state = State.ACTIVE;
+
+                    fireHandler(activeHandler, activeArgs);
+                } else {
+                     /*
+                      * Don't respond to clients yet - it's possible we're
+                      * performing a failback and the backup is currently active.
+                      */
+                    result = false;
+                }
+            }
+        } else if (state == State.BACKUP_CONNECTING) {
+             /*
+              * Backup server is waiting for peer to connect.
+              * Does not accept CLIENT_REQUEST events in this state.
+              */
+            if (event == Event.PEER_ACTIVE) {
+                log.info("Connected to primary (active), ready as passive");
+                state = State.PASSIVE;
+
+                fireHandler(passiveHandler, passiveArgs);
+            } else if (event == Event.CLIENT_REQUEST) {
+                 /*
+                  *  Reject client connections when acting as backup.
+                  */
+                result = false;
+            }
+        } else if (state == State.ACTIVE) {
+             /*
+              * Server is active.
+              * Accepts CLIENT_REQUEST events in this state.
+              */
+            if (event == Event.PEER_ACTIVE) {
+                 /*
+                  * Two actives would mean split-brain.
+                  */
+                log.error("Fatal error: Dual actives, aborting...");
+                result = false;
+            }
+        } else if (state == State.PASSIVE) {
+             /*
+              * Server is passive.
+              * CLIENT_REQUEST events can trigger failover if peer looks dead.
+              */
+            if (event == Event.PEER_PRIMARY) {
+                 /*
+                  * Peer is restarting - become active, peer will go passive.
+                  */
+                log.info("Primary (passive) is restarting, ready as active");
+                state = State.ACTIVE;
+
+                fireHandler(activeHandler, activeArgs);
+            } else if (event == Event.PEER_BACKUP) {
+                 /*
+                  * Peer is restarting - become active, peer will go passive.
+                  */
+                log.info("Backup (passive) is restarting, ready as active");
+                state = State.ACTIVE;
+
+                fireHandler(activeHandler, activeArgs);
+            } else if (event == Event.PEER_PASSIVE) {
+                 /*
+                  * Two passives would mean cluster would be non-responsive.
+                  */
+                log.error("Fatal error: Dual passives, aborting...");
+                result = false;
+            } else if (event == Event.CLIENT_REQUEST) {
+                 /*
+                  * Peer becomes active if timeout has passed.
+                  * It's the client request that triggers the failover.
+                  */
+                assert (peerExpiry > 0);
+                if (System.currentTimeMillis () >= peerExpiry) {
+                     /*
+                      * If peer is dead, switch to the active state.
+                      */
+                    log.info("Failover successful, ready as active");
+                    state = State.ACTIVE;
+                } else {
+                     /*
+                      * If peer is alive, reject connections.
+                      */
+                    result = false;
+                }
+
+                // Call state change handler if necessary
+                if (state == State.ACTIVE) {
+                    fireHandler(activeHandler, activeArgs);
+                }
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Publish our state to peer.
+     */
+    private final LoopHandler SEND_STATE = new LoopHandler() {
+        @Override
+        public void execute(Reactor reactor, Socket socket, Object... args) {
+            stateBuf.put(state.ordinal()).send(statePub);
+        }
+    };
+
+    /**
+     * Receive state from peer, execute finite state machine
+     */
+    private final LoopHandler RECEIVE_STATE = new LoopHandler() {
+        @Override
+        public void execute(Reactor reactor, Socket socket, Object... args) {
+            int ordinal = stateBuf.receive(stateSub);
+            assert (ordinal >= 0 && ordinal < Event.values().length);
+            updatePeerExpiry();
+
+            Event event = Event.values()[ordinal];
+            if (!handleEvent(event)) {
+                log.warn("Received fatal error: Restarting...");
+                state = (mode == Mode.PRIMARY)
+                    ? State.PRIMARY_CONNECTING
+                    : State.BACKUP_CONNECTING;
+            }
+        }
+    };
+
+    /**
+     * Application wants to speak to us, see if it's possible.
+     */
+    private final LoopHandler VOTER_READY = new LoopHandler() {
+        @Override
+        public void execute(Reactor reactor, Socket socket, Object... args) {
+            // If server can accept input now, call applicable handler
+            if (handleEvent(Event.CLIENT_REQUEST)) {
+                voterHandler.execute(reactor, socket, voterArgs);
+            } else {
+                // Destroy waiting message, no-one to read it
+                socket.receiveMessage();
+            }
+        }
+    };
+}

--- a/src/main/java/org/zeromq/jzmq/bstar/BinaryStarImpl.java
+++ b/src/main/java/org/zeromq/jzmq/bstar/BinaryStarImpl.java
@@ -2,7 +2,6 @@ package org.zeromq.jzmq.bstar;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.zeromq.ZMQ;
 import org.zeromq.api.BinaryStar;
 import org.zeromq.api.LoopHandler;
 import org.zeromq.api.PollerType;
@@ -11,7 +10,6 @@ import org.zeromq.api.Socket;
 import org.zeromq.api.SocketType;
 import org.zeromq.api.ZInteger;
 import org.zeromq.jzmq.ManagedContext;
-import org.zeromq.jzmq.sockets.SocketBuilder;
 
 public class BinaryStarImpl implements BinaryStar {
     private static final Logger log = LoggerFactory.getLogger(BinaryStarImpl.class);
@@ -63,7 +61,7 @@ public class BinaryStarImpl implements BinaryStar {
 
         // Create subscriber for state coming from peer
         this.stateSub = context.buildSocket(SocketType.SUB)
-            .asSubscribable().subscribe(ZMQ.SUBSCRIPTION_ALL)
+            .asSubscribable().subscribeAll()
             .connect(remote);
 
         // Set-up basic reactor events

--- a/src/main/java/org/zeromq/jzmq/bstar/BinaryStarImpl.java
+++ b/src/main/java/org/zeromq/jzmq/bstar/BinaryStarImpl.java
@@ -85,6 +85,14 @@ public class BinaryStarImpl implements BinaryStar {
     }
 
     /**
+     * Stop the reactor.
+     */
+    @Override
+    public void stop() {
+        reactor.stop();
+    }
+
+    /**
      * This method registers a client voter socket. Messages received
      * on this socket provide the CLIENT_REQUEST events for the Binary Star
      * FSM and are passed to the provided application handler. We require

--- a/src/main/java/org/zeromq/jzmq/bstar/BinaryStarReactorImpl.java
+++ b/src/main/java/org/zeromq/jzmq/bstar/BinaryStarReactorImpl.java
@@ -2,7 +2,7 @@ package org.zeromq.jzmq.bstar;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.zeromq.api.BinaryStar;
+import org.zeromq.api.BinaryStarReactor;
 import org.zeromq.api.LoopHandler;
 import org.zeromq.api.Pollable;
 import org.zeromq.api.PollerType;
@@ -12,8 +12,8 @@ import org.zeromq.api.SocketType;
 import org.zeromq.api.ZInteger;
 import org.zeromq.jzmq.ManagedContext;
 
-public class BinaryStarImpl implements BinaryStar {
-    private static final Logger log = LoggerFactory.getLogger(BinaryStarImpl.class);
+public class BinaryStarReactorImpl implements BinaryStarReactor {
+    private static final Logger log = LoggerFactory.getLogger(BinaryStarReactorImpl.class);
 
     private final ManagedContext context;
     private final Reactor reactor;
@@ -36,7 +36,7 @@ public class BinaryStarImpl implements BinaryStar {
     private Object[] passiveArgs;
 
     /**
-     * This is the constructor for our {@link BinaryStarImpl} class. We have to tell it
+     * This is the constructor for our {@link BinaryStarReactorImpl} class. We have to tell it
      * whether we're primary or backup server, as well as our local and
      * remote endpoints to bind and connect to.
      * 
@@ -44,7 +44,7 @@ public class BinaryStarImpl implements BinaryStar {
      * @param local The local socket endpoint for publishing events
      * @param remote The remote socket endpoint for subscribing to events
      */
-    public BinaryStarImpl(ManagedContext context, Mode mode, String local, String remote) {
+    public BinaryStarReactorImpl(ManagedContext context, Mode mode, String local, String remote) {
         // Initialize the Binary Star
         this.context = context;
         this.mode = mode;
@@ -91,7 +91,7 @@ public class BinaryStarImpl implements BinaryStar {
      * This method registers a client voter socket. Messages received
      * on this socket provide the CLIENT_REQUEST events for the Binary Star
      * FSM and are passed to the provided application handler. We require
-     * exactly one voter per {@link BinaryStarImpl} instance.
+     * exactly one voter per {@link BinaryStarReactorImpl} instance.
      *
      * @param socket The client socket
      */

--- a/src/main/java/org/zeromq/jzmq/bstar/BinaryStarSocketBuilder.java
+++ b/src/main/java/org/zeromq/jzmq/bstar/BinaryStarSocketBuilder.java
@@ -1,13 +1,13 @@
 package org.zeromq.jzmq.bstar;
 
-import org.zeromq.api.BinaryStar;
+import org.zeromq.api.BinaryStarReactor;
 import org.zeromq.api.Socket;
 import org.zeromq.jzmq.ManagedContext;
 import org.zeromq.jzmq.sockets.ReqSocketBuilder;
 
 public class BinaryStarSocketBuilder extends ReqSocketBuilder {
     public class Spec {
-        public long heartbeatInterval = BinaryStar.BSTAR_HEARTBEAT;
+        public long heartbeatInterval = BinaryStarReactor.BSTAR_HEARTBEAT;
     }
 
     private final Spec spec = new Spec();

--- a/src/main/java/org/zeromq/jzmq/bstar/BinaryStarSocketBuilder.java
+++ b/src/main/java/org/zeromq/jzmq/bstar/BinaryStarSocketBuilder.java
@@ -1,0 +1,46 @@
+package org.zeromq.jzmq.bstar;
+
+import org.zeromq.api.BinaryStar;
+import org.zeromq.api.Socket;
+import org.zeromq.jzmq.ManagedContext;
+import org.zeromq.jzmq.sockets.ReqSocketBuilder;
+
+public class BinaryStarSocketBuilder extends ReqSocketBuilder {
+    public class Spec {
+        public long heartbeatInterval = BinaryStar.BSTAR_HEARTBEAT;
+    }
+
+    private final Spec spec = new Spec();
+
+    public BinaryStarSocketBuilder(ManagedContext context) {
+        super(context);
+    }
+
+    public BinaryStarSocketBuilder withHeartbeatInterval(long heartbeatInterval) {
+        spec.heartbeatInterval = heartbeatInterval;
+        return this;
+    }
+
+    @Override
+    public Socket connect(String url, String... additionalUrls) {
+        Socket socket;
+        if (additionalUrls.length == 0) {
+            socket = super.connect(url, additionalUrls);
+        } else {
+            assert (additionalUrls.length == 1);
+            socket = fork(url, additionalUrls[0]);
+        }
+
+        return socket;
+    }
+
+    @Override
+    public Socket bind(String url, String... additionalUrls) {
+        throw new UnsupportedOperationException("Cannot bind to Binary Star server");
+    }
+
+    private Socket fork(String url1, String url2) {
+        BinaryStarClient client = new BinaryStarClient(this, url1, url2, spec.heartbeatInterval);
+        return context.fork(client);
+    }
+}

--- a/src/main/java/org/zeromq/jzmq/device/DeviceBuilder.java
+++ b/src/main/java/org/zeromq/jzmq/device/DeviceBuilder.java
@@ -1,0 +1,76 @@
+package org.zeromq.jzmq.device;
+
+import org.zeromq.api.DeviceType;
+import org.zeromq.api.Socket;
+import org.zeromq.api.SocketType;
+import org.zeromq.jzmq.ManagedContext;
+
+public class DeviceBuilder {
+    public class Spec {
+        public DeviceType deviceType;
+        public String frontend;
+        public String backend;
+    }
+    
+    private ManagedContext context;
+    private Spec spec = new Spec();
+
+    public DeviceBuilder(ManagedContext context, DeviceType deviceType) {
+        this.context = context;
+        spec.deviceType = deviceType;
+    }
+
+    public DeviceBuilder withFrontendUrl(String frontend) {
+        spec.frontend = frontend;
+        return this;
+    }
+
+    public DeviceBuilder withBackendUrl(String backend) {
+        spec.backend = backend;
+        return this;
+    }
+
+    public void start() {
+        switch (spec.deviceType) {
+            case STREAMER:
+                startStreamer();
+                break;
+            case FORWARDER:
+                startForwarder();
+                break;
+            case QUEUE:
+                startQueue();
+                break;
+        }
+    }
+
+    private void startStreamer() {
+        Socket frontend = context.buildSocket(SocketType.PULL)
+            .bind(spec.frontend);
+
+        Socket backend = context.buildSocket(SocketType.PUSH)
+            .bind(spec.backend);
+
+        context.forward(frontend, backend);
+    }
+
+    private void startForwarder() {
+        Socket frontend = context.buildSocket(SocketType.XSUB)
+            .bind(spec.frontend);
+
+        Socket backend = context.buildSocket(SocketType.XPUB)
+            .bind(spec.backend);
+
+        context.forward(frontend, backend);
+    }
+
+    private void startQueue() {
+        Socket frontend = context.buildSocket(SocketType.ROUTER)
+            .bind(spec.frontend);
+
+        Socket backend = context.buildSocket(SocketType.DEALER)
+            .bind(spec.backend);
+
+        context.forward(frontend, backend);
+    }
+}

--- a/src/main/java/org/zeromq/jzmq/poll/PollableImpl.java
+++ b/src/main/java/org/zeromq/jzmq/poll/PollableImpl.java
@@ -4,21 +4,35 @@ import org.zeromq.api.Pollable;
 import org.zeromq.api.PollerType;
 import org.zeromq.api.Socket;
 
+import java.nio.channels.SelectableChannel;
 import java.util.Arrays;
 import java.util.EnumSet;
 
 public class PollableImpl implements Pollable {
     private final Socket socket;
+    private final SelectableChannel channel;
     private final PollerType[] options;
 
     public PollableImpl(Socket socket, PollerType... options) {
         this.socket = socket;
+        this.channel = null;
+        this.options = options;
+    }
+
+    public PollableImpl(SelectableChannel channel, PollerType... options) {
+        this.socket = null;
+        this.channel = channel;
         this.options = options;
     }
 
     @Override
     public Socket getSocket() {
         return socket;
+    }
+
+    @Override
+    public SelectableChannel getChannel() {
+        return channel;
     }
 
     @Override

--- a/src/main/java/org/zeromq/jzmq/poll/PollerBuilder.java
+++ b/src/main/java/org/zeromq/jzmq/poll/PollerBuilder.java
@@ -7,13 +7,13 @@ import org.zeromq.api.PollerType;
 import org.zeromq.api.Socket;
 import org.zeromq.jzmq.ManagedContext;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class PollerBuilder {
 
     private final ManagedContext context;
-    private Map<Pollable, PollListener> pollablesAndListeners = new HashMap<Pollable, PollListener>();
+    private final Map<Pollable, PollListener> pollablesAndListeners = new LinkedHashMap<>();
 
     public PollerBuilder(ManagedContext context) {
         this.context = context;
@@ -44,7 +44,12 @@ public class PollerBuilder {
         return withPollable(context.newPollable(socket, PollerType.POLL_IN, PollerType.POLL_OUT, PollerType.POLL_ERROR), listener);
     }
 
+    @Deprecated
     public Poller create() {
+        return build();
+    }
+
+    public Poller build() {
         return new PollerImpl(context, pollablesAndListeners);
     }
 }

--- a/src/main/java/org/zeromq/jzmq/poll/PollerBuilder.java
+++ b/src/main/java/org/zeromq/jzmq/poll/PollerBuilder.java
@@ -7,6 +7,7 @@ import org.zeromq.api.PollerType;
 import org.zeromq.api.Socket;
 import org.zeromq.jzmq.ManagedContext;
 
+import java.nio.channels.SelectableChannel;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -23,6 +24,10 @@ public class PollerBuilder {
         pollablesAndListeners.put(pollable, listener);
         return this;
     }
+
+    /*
+     * Socket Pollables.
+     */
 
     public PollerBuilder withInPollable(Socket socket, PollListener listener) {
         return withPollable(context.newPollable(socket, PollerType.POLL_IN), listener);
@@ -42,6 +47,30 @@ public class PollerBuilder {
 
     public PollerBuilder withAllPollable(Socket socket, PollListener listener) {
         return withPollable(context.newPollable(socket, PollerType.POLL_IN, PollerType.POLL_OUT, PollerType.POLL_ERROR), listener);
+    }
+
+    /*
+     * SelectableChannel Pollables.
+     */
+
+    public PollerBuilder withInPollable(SelectableChannel channel, PollListener listener) {
+        return withPollable(context.newPollable(channel, PollerType.POLL_IN), listener);
+    }
+
+    public PollerBuilder withOutPollable(SelectableChannel channel, PollListener listener) {
+        return withPollable(context.newPollable(channel, PollerType.POLL_OUT), listener);
+    }
+
+    public PollerBuilder withErrorPollable(SelectableChannel channel, PollListener listener) {
+        return withPollable(context.newPollable(channel, PollerType.POLL_ERROR), listener);
+    }
+
+    public PollerBuilder withInOutPollable(SelectableChannel channel, PollListener listener) {
+        return withPollable(context.newPollable(channel, PollerType.POLL_IN, PollerType.POLL_OUT), listener);
+    }
+
+    public PollerBuilder withAllPollable(SelectableChannel channel, PollListener listener) {
+        return withPollable(context.newPollable(channel, PollerType.POLL_IN, PollerType.POLL_OUT, PollerType.POLL_ERROR), listener);
     }
 
     @Deprecated

--- a/src/main/java/org/zeromq/jzmq/poll/PollerImpl.java
+++ b/src/main/java/org/zeromq/jzmq/poll/PollerImpl.java
@@ -1,7 +1,6 @@
 package org.zeromq.jzmq.poll;
 
 import java.util.EnumSet;
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.zeromq.ZMQ;
@@ -15,13 +14,12 @@ import org.zeromq.api.exception.ZMQExceptions;
 import org.zeromq.jzmq.ManagedContext;
 
 public class PollerImpl implements Poller {
-
     private final Map<Pollable, PollListener> pollables;
     private final ZMQ.Poller poller;
 
     public PollerImpl(ManagedContext context, Map<Pollable, PollListener> pollables) {
         this.poller = context.newZmqPoller(pollables.size());
-        this.pollables = new LinkedHashMap<Pollable, PollListener>(pollables);
+        this.pollables = pollables;
         for (Pollable pollable : pollables.keySet()) {
             register(pollable);
         }
@@ -81,18 +79,24 @@ public class PollerImpl implements Poller {
         if (pollable != null) {
             result = register(pollable);
         }
+
         return result;
     }
 
     @Override
     public boolean disable(Socket socket) {
-        boolean result = false;
         Pollable pollable = pollable(socket);
         if (pollable != null) {
             poller.unregister(socket.getZMQSocket());
-            result = true;
         }
-        return result;
+
+        return (pollable != null);
+    }
+
+    @Override
+    public int register(Pollable pollable, PollListener listener) {
+        pollables.put(pollable, listener);
+        return register(pollable);
     }
 
     private int register(Pollable pollable) {

--- a/src/main/java/org/zeromq/jzmq/poll/PollerImpl.java
+++ b/src/main/java/org/zeromq/jzmq/poll/PollerImpl.java
@@ -44,6 +44,11 @@ public class PollerImpl implements Poller {
             if (numberOfObjects == 0) {
                 return;
             }
+
+            // simulate ETERM to make JeroMQ act like jzmq, which no longer returns -1
+            if (numberOfObjects < 0) {
+                throw new ZMQException("Simulated ETERM error", ZMQ.Error.ETERM.getCode());
+            }
         } catch (ZMQException ex) {
             throw ZMQExceptions.wrap(ex);
         }

--- a/src/main/java/org/zeromq/jzmq/poll/PollerImpl.java
+++ b/src/main/java/org/zeromq/jzmq/poll/PollerImpl.java
@@ -46,7 +46,7 @@ public class PollerImpl implements Poller {
 
             // simulate ETERM to make JeroMQ act like jzmq, which no longer returns -1
             if (numberOfObjects < 0) {
-                throw new ZMQException("Simulated ETERM error", ZMQ.Error.ETERM.getCode());
+                throw new ZMQException("Simulated ETERM error", (int) ZMQ.Error.ETERM.getCode());
             }
         } catch (ZMQException ex) {
             throw ZMQExceptions.wrap(ex);

--- a/src/main/java/org/zeromq/jzmq/poll/PollerImpl.java
+++ b/src/main/java/org/zeromq/jzmq/poll/PollerImpl.java
@@ -10,6 +10,7 @@ import org.zeromq.api.Socket;
 import org.zeromq.api.exception.ZMQExceptions;
 import org.zeromq.jzmq.ManagedContext;
 
+import java.nio.channels.SelectableChannel;
 import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -54,14 +55,14 @@ public class PollerImpl implements Poller {
 
         int index = 0;
         for (Map.Entry<Pollable, PollListener> entry : pollables.entrySet()) {
-            Socket socket = entry.getKey().getSocket();
+            Pollable pollable = entry.getKey();
             PollListener listener = entry.getValue();
             if (poller.pollin(index))
-                listener.handleIn(socket);
+                listener.handleIn(pollable);
             if (poller.pollout(index))
-                listener.handleOut(socket);
+                listener.handleOut(pollable);
             if (poller.pollerr(index))
-                listener.handleError(socket);
+                listener.handleError(pollable);
 
             index++;
         }
@@ -94,19 +95,55 @@ public class PollerImpl implements Poller {
     }
 
     @Override
+    public int enable(SelectableChannel channel) {
+        int result = -1;
+        Pollable pollable = pollable(channel);
+        if (pollable != null) {
+            result = register(pollable);
+        }
+
+        return result;
+    }
+
+    @Override
+    public boolean disable(SelectableChannel channel) {
+        Pollable pollable = pollable(channel);
+        if (pollable != null) {
+            poller.unregister(channel);
+        }
+
+        return (pollable != null);
+    }
+
+    @Override
     public int register(Pollable pollable, PollListener listener) {
         pollables.put(pollable, listener);
         return register(pollable);
     }
 
     private int register(Pollable pollable) {
-        return poller.register(pollable.getSocket().getZMQSocket(), sumOptions(pollable));
+        if (pollable.getChannel() != null) {
+            return poller.register(pollable.getChannel(), sumOptions(pollable));
+        } else {
+            return poller.register(pollable.getSocket().getZMQSocket(), sumOptions(pollable));
+        }
     }
 
     private Pollable pollable(Socket socket) {
         Pollable result = null;
         for (Pollable pollable : pollables.keySet()) {
             if (pollable.getSocket() == socket) {
+                result = pollable;
+                break;
+            }
+        }
+        return result;
+    }
+
+    private Pollable pollable(SelectableChannel channel) {
+        Pollable result = null;
+        for (Pollable pollable : pollables.keySet()) {
+            if (pollable.getChannel() == channel) {
                 result = pollable;
                 break;
             }

--- a/src/main/java/org/zeromq/jzmq/poll/PollerImpl.java
+++ b/src/main/java/org/zeromq/jzmq/poll/PollerImpl.java
@@ -1,8 +1,5 @@
 package org.zeromq.jzmq.poll;
 
-import java.util.EnumSet;
-import java.util.Map;
-
 import org.zeromq.ZMQ;
 import org.zeromq.ZMQException;
 import org.zeromq.api.PollListener;
@@ -13,13 +10,17 @@ import org.zeromq.api.Socket;
 import org.zeromq.api.exception.ZMQExceptions;
 import org.zeromq.jzmq.ManagedContext;
 
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 public class PollerImpl implements Poller {
     private final Map<Pollable, PollListener> pollables;
     private final ZMQ.Poller poller;
 
     public PollerImpl(ManagedContext context, Map<Pollable, PollListener> pollables) {
         this.poller = context.newZmqPoller(pollables.size());
-        this.pollables = pollables;
+        this.pollables = new LinkedHashMap<>(pollables);
         for (Pollable pollable : pollables.keySet()) {
             register(pollable);
         }
@@ -64,7 +65,6 @@ public class PollerImpl implements Poller {
 
             index++;
         }
-
     }
 
     @Override

--- a/src/main/java/org/zeromq/jzmq/reactor/PollItem.java
+++ b/src/main/java/org/zeromq/jzmq/reactor/PollItem.java
@@ -1,0 +1,41 @@
+package org.zeromq.jzmq.reactor;
+
+import org.zeromq.api.LoopHandler;
+import org.zeromq.api.PollListener;
+import org.zeromq.api.Pollable;
+import org.zeromq.api.Reactor;
+import org.zeromq.api.Socket;
+
+class PollItem implements PollListener {
+    private Reactor reactor;
+
+    public Pollable pollable;
+    public LoopHandler handler;
+    public Object[] args;
+
+    public PollItem(Reactor reactor, Pollable pollable, LoopHandler handler, Object... args) {
+        this.reactor = reactor;
+        this.pollable = pollable;
+        this.handler = handler;
+        this.args = args;
+    }
+
+    @Override
+    public void handleIn(Socket socket) {
+        execute(socket);
+    }
+
+    @Override
+    public void handleOut(Socket socket) {
+        execute(socket);
+    }
+
+    @Override
+    public void handleError(Socket socket) {
+        execute(socket);
+    }
+
+    private void execute(Socket socket) {
+        handler.execute(reactor, socket, args);
+    }
+}

--- a/src/main/java/org/zeromq/jzmq/reactor/PollItem.java
+++ b/src/main/java/org/zeromq/jzmq/reactor/PollItem.java
@@ -1,12 +1,11 @@
 package org.zeromq.jzmq.reactor;
 
 import org.zeromq.api.LoopHandler;
-import org.zeromq.api.PollListener;
+import org.zeromq.api.PollAdapter;
 import org.zeromq.api.Pollable;
 import org.zeromq.api.Reactor;
-import org.zeromq.api.Socket;
 
-class PollItem implements PollListener {
+class PollItem extends PollAdapter {
     private Reactor reactor;
 
     public Pollable pollable;
@@ -21,21 +20,21 @@ class PollItem implements PollListener {
     }
 
     @Override
-    public void handleIn(Socket socket) {
-        execute(socket);
+    public void handleIn(Pollable pollable) {
+        execute(pollable);
     }
 
     @Override
-    public void handleOut(Socket socket) {
-        execute(socket);
+    public void handleOut(Pollable pollable) {
+        execute(pollable);
     }
 
     @Override
-    public void handleError(Socket socket) {
-        execute(socket);
+    public void handleError(Pollable pollable) {
+        execute(pollable);
     }
 
-    private void execute(Socket socket) {
-        handler.execute(reactor, socket, args);
+    private void execute(Pollable pollable) {
+        handler.execute(reactor, pollable, args);
     }
 }

--- a/src/main/java/org/zeromq/jzmq/reactor/ReactorBuilder.java
+++ b/src/main/java/org/zeromq/jzmq/reactor/ReactorBuilder.java
@@ -7,6 +7,8 @@ import org.zeromq.api.Reactor;
 import org.zeromq.api.Socket;
 import org.zeromq.jzmq.ManagedContext;
 
+import java.nio.channels.SelectableChannel;
+
 public class ReactorBuilder {
     private final ManagedContext context;
     private final ReactorImpl reactor;
@@ -15,6 +17,10 @@ public class ReactorBuilder {
         this.context = context;
         this.reactor = newReactor();
     }
+
+    /*
+     * Socket Pollables.
+     */
 
     public ReactorBuilder withPollable(Pollable pollable, LoopHandler handler, Object... args) {
         reactor.addPollable(pollable, handler, args);
@@ -40,6 +46,34 @@ public class ReactorBuilder {
     public ReactorBuilder withAllPollable(Socket socket, LoopHandler handler, Object... args) {
         return withPollable(context.newPollable(socket, PollerType.POLL_IN, PollerType.POLL_OUT, PollerType.POLL_ERROR), handler, args);
     }
+
+    /*
+     * SelectableChannel Pollables.
+     */
+
+    public ReactorBuilder withInPollable(SelectableChannel channel, LoopHandler handler, Object... args) {
+        return withPollable(context.newPollable(channel, PollerType.POLL_IN), handler, args);
+    }
+
+    public ReactorBuilder withOutPollable(SelectableChannel channel, LoopHandler handler, Object... args) {
+        return withPollable(context.newPollable(channel, PollerType.POLL_OUT), handler, args);
+    }
+
+    public ReactorBuilder withErrorPollable(SelectableChannel channel, LoopHandler handler, Object... args) {
+        return withPollable(context.newPollable(channel, PollerType.POLL_ERROR), handler, args);
+    }
+
+    public ReactorBuilder withInOutPollable(SelectableChannel channel, LoopHandler handler, Object... args) {
+        return withPollable(context.newPollable(channel, PollerType.POLL_IN, PollerType.POLL_OUT), handler, args);
+    }
+
+    public ReactorBuilder withAllPollable(SelectableChannel channel, LoopHandler handler, Object... args) {
+        return withPollable(context.newPollable(channel, PollerType.POLL_IN, PollerType.POLL_OUT, PollerType.POLL_ERROR), handler, args);
+    }
+
+    /*
+     * Timer Pollables.
+     */
 
     public ReactorBuilder withTimer(long initialDelay, int numIterations, LoopHandler handler, Object... args) {
         reactor.addTimer(initialDelay, numIterations, handler, args);

--- a/src/main/java/org/zeromq/jzmq/reactor/ReactorBuilder.java
+++ b/src/main/java/org/zeromq/jzmq/reactor/ReactorBuilder.java
@@ -1,0 +1,72 @@
+package org.zeromq.jzmq.reactor;
+
+import org.zeromq.api.LoopHandler;
+import org.zeromq.api.Pollable;
+import org.zeromq.api.PollerType;
+import org.zeromq.api.Reactor;
+import org.zeromq.api.Socket;
+import org.zeromq.jzmq.ManagedContext;
+
+public class ReactorBuilder {
+    private final ManagedContext context;
+    private final ReactorImpl reactor;
+
+    public ReactorBuilder(ManagedContext context) {
+        this.context = context;
+        this.reactor = newReactor();
+    }
+
+    public ReactorBuilder withPollable(Pollable pollable, LoopHandler handler, Object... args) {
+        reactor.addPollable(pollable, handler, args);
+        return this;
+    }
+
+    public ReactorBuilder withInPollable(Socket socket, LoopHandler handler, Object... args) {
+        return withPollable(context.newPollable(socket, PollerType.POLL_IN), handler, args);
+    }
+
+    public ReactorBuilder withOutPollable(Socket socket, LoopHandler handler, Object... args) {
+        return withPollable(context.newPollable(socket, PollerType.POLL_OUT), handler, args);
+    }
+
+    public ReactorBuilder withErrorPollable(Socket socket, LoopHandler handler, Object... args) {
+        return withPollable(context.newPollable(socket, PollerType.POLL_ERROR), handler, args);
+    }
+
+    public ReactorBuilder withInOutPollable(Socket socket, LoopHandler handler, Object... args) {
+        return withPollable(context.newPollable(socket, PollerType.POLL_IN, PollerType.POLL_OUT), handler, args);
+    }
+
+    public ReactorBuilder withAllPollable(Socket socket, LoopHandler handler, Object... args) {
+        return withPollable(context.newPollable(socket, PollerType.POLL_IN, PollerType.POLL_OUT, PollerType.POLL_ERROR), handler, args);
+    }
+
+    public ReactorBuilder withTimer(long initialDelay, int numIterations, LoopHandler handler, Object... args) {
+        reactor.addTimer(initialDelay, numIterations, handler, args);
+        return this;
+    }
+
+    public ReactorBuilder withTimerOnce(long initialDelay, LoopHandler handler, Object... args) {
+        return withTimer(initialDelay, 1, handler, args);
+    }
+
+    public ReactorBuilder withTimerRepeating(long initialDelay, LoopHandler handler, Object... args) {
+        return withTimer(initialDelay, -1, handler, args);
+    }
+
+    public Reactor build() {
+        return reactor;
+    }
+
+    public void start() {
+        newReactor().start();
+    }
+
+    public void run() {
+        newReactor().run();
+    }
+
+    private ReactorImpl newReactor() {
+        return new ReactorImpl(context);
+    }
+}

--- a/src/main/java/org/zeromq/jzmq/reactor/ReactorImpl.java
+++ b/src/main/java/org/zeromq/jzmq/reactor/ReactorImpl.java
@@ -1,0 +1,125 @@
+package org.zeromq.jzmq.reactor;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.PriorityQueue;
+import java.util.Queue;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.zeromq.api.LoopHandler;
+import org.zeromq.api.Pollable;
+import org.zeromq.api.Poller;
+import org.zeromq.api.Reactor;
+import org.zeromq.api.exception.ContextTerminatedException;
+import org.zeromq.api.exception.InvalidSocketException;
+import org.zeromq.jzmq.ManagedContext;
+
+public class ReactorImpl extends Thread implements Reactor {
+    private static final Logger log = LoggerFactory.getLogger(Reactor.class);
+
+    private final Poller poller;
+
+    private final List<PollItem> pollItems;
+    private final Queue<ReactorTimer> timers;
+
+    public ReactorImpl(ManagedContext context) {
+        this.pollItems = new ArrayList<>();
+        this.timers = new PriorityQueue<>();
+        this.poller = context.buildPoller().build();
+    }
+
+    @Override
+    public void addPollable(Pollable pollable, LoopHandler handler, Object... args) {
+        PollItem pollItem = new PollItem(this, pollable, handler, args);
+        pollItems.add(pollItem);
+        poller.register(pollable, pollItem);
+    }
+
+    @Override
+    public void addTimer(long initialDelay, int numIterations, LoopHandler handler, Object... args) {
+        ReactorTimer timer = new ReactorTimer(initialDelay, numIterations, handler, args);
+        timer.recalculate(System.currentTimeMillis());
+
+        timers.add(timer);
+    }
+
+    @Override
+    public void cancel(LoopHandler handler) {
+        // find the handler in pollers
+        for (Iterator<PollItem> it = pollItems.iterator(); it.hasNext();) {
+            PollItem item = it.next();
+            if (item.handler == handler) {
+                it.remove();
+                if (poller != null) {
+                    poller.disable(item.pollable.getSocket());
+                }
+            }
+        }
+
+        // find the handler in timers
+        for (Iterator<ReactorTimer> it = timers.iterator(); it.hasNext();) {
+            if (it.next().handler == handler) {
+                it.remove();
+            }
+        }
+    }
+
+    @Override
+    public void run() {
+        // Main reactor loop
+        while (!Thread.currentThread().isInterrupted()) {
+            long wait = ticklessTimer();
+            try {
+                /*
+                 * Pollers will execute internally.
+                 * 
+                 * NOTE: This call can cause new timers and pollers to be
+                 * registered internally, using a handle to this Reactor.
+                 */
+                poller.poll(wait);
+            } catch (ContextTerminatedException | InvalidSocketException ex) {
+                break;
+            }
+
+            // Handle any timers that have now expired
+            long now = System.currentTimeMillis();
+            while (!timers.isEmpty()
+                    && timers.peek().nextFireTime <= now) {
+                /*
+                 * Remove timer from queue to execute it.
+                 *
+                 * NOTE: This call can cause new timers and pollers to be
+                 * registered internally, using a handle to this Reactor.
+                 */
+                ReactorTimer timer = timers.poll();
+                timer.execute(this);
+
+                // Re-add repeating timer
+                if (timer.numIterations > 0 || timer.numIterations == -1) {
+                    timer.recalculate(now);
+                    timers.add(timer);
+                }
+            }
+        }
+
+        log.info("Exiting reactor");
+    }
+
+    private long ticklessTimer() {
+        // Calculate tickless timer, up to 1 hour
+        long now = System.currentTimeMillis();
+        long tickless = now + 1000 * 3600;
+        if (timers.peek() != null) {
+            tickless = timers.peek().nextFireTime;
+        }
+
+        long timeout = tickless - now;
+        if (timeout < 0) {
+            timeout = 0;
+        }
+
+        return timeout;
+    }
+}

--- a/src/main/java/org/zeromq/jzmq/reactor/ReactorImpl.java
+++ b/src/main/java/org/zeromq/jzmq/reactor/ReactorImpl.java
@@ -56,7 +56,11 @@ public class ReactorImpl implements Reactor, Runnable {
             if (item.handler == handler) {
                 it.remove();
                 if (poller != null) {
-                    poller.disable(item.pollable.getSocket());
+                    if (item.pollable.getChannel() != null) {
+                        poller.disable(item.pollable.getChannel());
+                    } else {
+                        poller.disable(item.pollable.getSocket());
+                    }
                 }
             }
         }

--- a/src/main/java/org/zeromq/jzmq/reactor/ReactorTimer.java
+++ b/src/main/java/org/zeromq/jzmq/reactor/ReactorTimer.java
@@ -1,0 +1,45 @@
+package org.zeromq.jzmq.reactor;
+
+import org.zeromq.api.LoopHandler;
+import org.zeromq.api.Reactor;
+
+class ReactorTimer implements Comparable<ReactorTimer> {
+    public long initialDelay;
+    public int numIterations;
+    public LoopHandler handler;
+    public Object[] args;
+
+    public long nextFireTime = -1;
+
+    public ReactorTimer(long initialDelay, int numIterations, LoopHandler handler, Object... args) {
+        this.initialDelay = initialDelay;
+        this.numIterations = numIterations;
+        this.handler = handler;
+        this.args = args;
+    }
+
+    public void recalculate(long now) {
+        nextFireTime = now + initialDelay;
+    }
+
+    public void execute(Reactor reactor) {
+        handler.execute(reactor, null, args);
+
+        // Decrement counter if applicable
+        if (numIterations > 0) {
+            numIterations--;
+        }
+    }
+
+    @Override
+    public int compareTo(ReactorTimer other) {
+        int result = 0;
+        if (nextFireTime < other.nextFireTime) {
+            result = -1;
+        } else if (nextFireTime > other.nextFireTime) {
+            result = 1;
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/org/zeromq/jzmq/sockets/SocketBuilder.java
+++ b/src/main/java/org/zeromq/jzmq/sockets/SocketBuilder.java
@@ -288,7 +288,7 @@ public class SocketBuilder implements Bindable, Connectable {
      * Coerce the SocketBuilder to be Subscribable
      */
     public Subscribable asSubscribable() {
-        return (SubSocketBuilder) this;
+        return (Subscribable) this;
     }
 
     /**

--- a/src/main/java/org/zeromq/jzmq/sockets/SocketBuilder.java
+++ b/src/main/java/org/zeromq/jzmq/sockets/SocketBuilder.java
@@ -35,7 +35,7 @@ public class SocketBuilder implements Bindable, Connectable {
         public byte[] identity;
         public Backgroundable backgroundable;
         public Object[] backgroundableArgs;
-    };
+    }
 
     public SocketBuilder(ManagedContext context, SocketType socketType) {
         this.socketSpec = new SocketSpec();

--- a/src/main/java/org/zeromq/jzmq/sockets/SubSocketBuilder.java
+++ b/src/main/java/org/zeromq/jzmq/sockets/SubSocketBuilder.java
@@ -21,6 +21,11 @@ public class SubSocketBuilder extends SocketBuilder implements Subscribable {
     }
 
     @Override
+    public SocketBuilder subscribeAll() {
+        return subscribe(new byte[0]);
+    }
+
+    @Override
     public Socket connect(String url, String... additionalUrls) {
         if (subscription == null) {
             throw new IllegalStateException("You must have a SUB socket subscribe to something before you can connect it.");

--- a/src/main/java/org/zeromq/jzmq/sockets/XPubSocketBuilder.java
+++ b/src/main/java/org/zeromq/jzmq/sockets/XPubSocketBuilder.java
@@ -1,0 +1,12 @@
+package org.zeromq.jzmq.sockets;
+
+import org.zeromq.api.SocketType;
+import org.zeromq.jzmq.ManagedContext;
+
+public class XPubSocketBuilder extends SocketBuilder {
+
+    public XPubSocketBuilder(ManagedContext context) {
+        super(context, SocketType.XPUB);
+    }
+
+}

--- a/src/main/java/org/zeromq/jzmq/sockets/XSubSocketBuilder.java
+++ b/src/main/java/org/zeromq/jzmq/sockets/XSubSocketBuilder.java
@@ -1,0 +1,12 @@
+package org.zeromq.jzmq.sockets;
+
+import org.zeromq.api.SocketType;
+import org.zeromq.jzmq.ManagedContext;
+
+public class XSubSocketBuilder extends SocketBuilder {
+
+    public XSubSocketBuilder(ManagedContext context) {
+        super(context, SocketType.XSUB);
+    }
+
+}

--- a/src/test/java/org/zeromq/api/BeaconReactorTest.java
+++ b/src/test/java/org/zeromq/api/BeaconReactorTest.java
@@ -1,0 +1,105 @@
+package org.zeromq.api;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.zeromq.jzmq.ManagedContext;
+import org.zeromq.jzmq.beacon.BeaconReactorImpl;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class BeaconReactorTest {
+    private ManagedContext context;
+    private BeaconReactor reactor1;
+    private BeaconReactor reactor2;
+    private BeaconReactor reactor3;
+
+    private AtomicInteger beacon1 = new AtomicInteger();
+    private AtomicInteger beacon2 = new AtomicInteger();
+    private AtomicInteger beacon3 = new AtomicInteger();
+
+    @Before
+    public void setUp() throws Exception {
+        context = new ManagedContext();
+        startBeaconReactor1();
+        startBeaconReactor2();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        reactor1.stop();
+        reactor2.stop();
+        if (reactor3 != null) {
+            reactor3.stop();
+        }
+        context.close();
+    }
+
+    private void startBeaconReactor1() throws IOException {
+        reactor2 = context.buildBeaconReactor()
+            .withPort(1234)
+            .withIgnoreLocalAddress(false)
+            .withBroadcastInterval(250)
+            .withBeacon(new UdpBeacon(1, "TEST", UUID.randomUUID(), 1234))
+            .withListener(new BeaconListener() {
+                @Override
+                public void onBeacon(InetAddress sender, UdpBeacon beacon) {
+                    beacon1.incrementAndGet();
+                }
+            })
+            .start();
+    }
+
+    private void startBeaconReactor2() throws IOException {
+        reactor1 = context.buildBeaconReactor()
+            .withPort(1234)
+            .withIgnoreLocalAddress(false)
+            .withBroadcastInterval(250)
+            .withBeacon(new UdpBeacon(1, "TEST", UUID.randomUUID(), 1234))
+            .withListener(new BeaconListener() {
+                @Override
+                public void onBeacon(InetAddress sender, UdpBeacon beacon) {
+                    beacon2.incrementAndGet();
+                }
+            })
+            .start();
+    }
+
+    private void startBeaconReactor3() throws IOException {
+        reactor3 = context.buildBeaconReactor()
+            .withPort(1234)
+            .withIgnoreLocalAddress(true)
+            .withBroadcastInterval(250)
+            .withBeacon(new UdpBeacon(2, "X", UUID.randomUUID(), 1234))
+            .withListener(new BeaconListener() {
+                @Override
+                public void onBeacon(InetAddress sender, UdpBeacon beacon) {
+                    beacon3.incrementAndGet();
+                }
+            })
+            .start();
+    }
+
+    @Test
+    public void testBeaconReactor() throws Exception {
+        Thread.sleep(550);
+
+        assertEquals(4, beacon1.get());
+        assertEquals(4, beacon2.get());
+    }
+
+    @Test
+    public void testBeaconReactor_InvalidBeacon() throws Exception {
+        startBeaconReactor3();
+        Thread.sleep(550);
+
+        assertEquals(4, beacon1.get());
+        assertEquals(4, beacon2.get());
+        assertEquals(0, beacon3.get());
+    }
+}

--- a/src/test/java/org/zeromq/api/BinaryStarClientTest.java
+++ b/src/test/java/org/zeromq/api/BinaryStarClientTest.java
@@ -1,0 +1,23 @@
+package org.zeromq.api;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.zeromq.jzmq.ManagedContext;
+
+public class BinaryStarClientTest {
+    private ManagedContext context;
+
+    @Before
+    public void setUp() {
+        context = new ManagedContext();
+    }
+    
+    @After
+    public void tearDown() throws Exception {
+    }
+    
+    @Test
+    public void test() throws Exception {
+    }
+}

--- a/src/test/java/org/zeromq/api/BinaryStarReactorTest.java
+++ b/src/test/java/org/zeromq/api/BinaryStarReactorTest.java
@@ -9,14 +9,14 @@ import org.zeromq.jzmq.ManagedContext;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
-public class BinaryStarTest {
+public class BinaryStarReactorTest {
     private Context context;
     private Socket socket;
 
     private Context context1;
-    private BinaryStar primary;
+    private BinaryStarReactor primary;
     private Context context2;
-    private BinaryStar backup;
+    private BinaryStarReactor backup;
 
     private AtomicInteger primaryVoter = new AtomicInteger();
     private AtomicInteger primaryActive = new AtomicInteger();
@@ -54,8 +54,8 @@ public class BinaryStarTest {
 
     private void startPrimary() {
         context1 = new ManagedContext();
-        primary = context1.buildBinaryStar()
-            .withMode(BinaryStar.Mode.PRIMARY)
+        primary = context1.buildBinaryStarReactor()
+            .withMode(BinaryStarReactor.Mode.PRIMARY)
             .withLocalUrl("tcp://*:5555")
             .withRemoteUrl("tcp://localhost:5556")
             .withHeartbeatInterval(250)
@@ -85,8 +85,8 @@ public class BinaryStarTest {
 
     private void startBackup() {
         context2 = new ManagedContext();
-        backup = context2.buildBinaryStar()
-            .withMode(BinaryStar.Mode.BACKUP)
+        backup = context2.buildBinaryStarReactor()
+            .withMode(BinaryStarReactor.Mode.BACKUP)
             .withLocalUrl("tcp://*:5556")
             .withRemoteUrl("tcp://localhost:5555")
             .withHeartbeatInterval(250)

--- a/src/test/java/org/zeromq/api/BinaryStarTest.java
+++ b/src/test/java/org/zeromq/api/BinaryStarTest.java
@@ -4,9 +4,7 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
-import org.zeromq.ZMQ;
 import org.zeromq.jzmq.ManagedContext;
 
 import java.util.concurrent.atomic.AtomicInteger;
@@ -98,18 +96,12 @@ public class BinaryStarTest {
 
     @After
     public void tearDown() {
-        context1.terminate();
+        primary.stop();
         context1.close();
-        context2.terminate();
+        backup.stop();
         context2.close();
 
         context.close();
-    }
-
-    @Test
-    @Ignore
-    public void testAlive() throws Exception {
-        Thread.sleep(Long.MAX_VALUE);
     }
 
     @Test

--- a/src/test/java/org/zeromq/api/BinaryStarTest.java
+++ b/src/test/java/org/zeromq/api/BinaryStarTest.java
@@ -1,0 +1,152 @@
+package org.zeromq.api;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.zeromq.ZMQ;
+import org.zeromq.jzmq.ManagedContext;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class BinaryStarTest {
+    private Context context;
+    private Socket socket;
+
+    private Context context1;
+    private BinaryStar primary;
+    private Context context2;
+    private BinaryStar backup;
+
+    private AtomicInteger primaryVoter = new AtomicInteger();
+    private AtomicInteger primaryActive = new AtomicInteger();
+    private AtomicInteger primaryPassive = new AtomicInteger();
+    private AtomicInteger backupVoter = new AtomicInteger();
+    private AtomicInteger backupActive = new AtomicInteger();
+    private AtomicInteger backupPassive = new AtomicInteger();
+
+    @Before
+    public void setUp() throws Exception {
+        context = new ManagedContext();
+        socket = context.buildSocket(SocketType.PUB)
+            .connect("tcp://localhost:5557", "tcp://localhost:5558");
+
+        startPrimary();
+        startBackup();
+        Thread.sleep(100);
+    }
+
+    private void startPrimary() {
+        context1 = new ManagedContext();
+        primary = context1.buildBinaryStar()
+            .withMode(BinaryStar.Mode.PRIMARY)
+            .withLocalUrl("tcp://localhost:5555")
+            .withRemoteUrl("tcp://localhost:5556")
+            .withVoterSocket("tcp://localhost:5557")
+            .withVoterHandler(new LoopHandler() {
+                @Override
+                public void execute(Reactor reactor, Socket socket, Object... args) {
+                    primaryVoter.incrementAndGet();
+                    socket.receiveMessage();
+                }
+            })
+            .withActiveHandler(new LoopHandler() {
+                @Override
+                public void execute(Reactor reactor, Socket socket, Object... args) {
+                    primaryActive.incrementAndGet();
+                }
+            })
+            .withPassiveHandler(new LoopHandler() {
+                @Override
+                public void execute(Reactor reactor, Socket socket, Object... args) {
+                    primaryPassive.incrementAndGet();
+                }
+            })
+            .start();
+    }
+
+    private void startBackup() {
+        context2 = new ManagedContext();
+        backup = context2.buildBinaryStar()
+            .withMode(BinaryStar.Mode.BACKUP)
+            .withLocalUrl("tcp://localhost:5556")
+            .withRemoteUrl("tcp://localhost:5555")
+            .withVoterSocket("tcp://localhost:5558")
+            .withVoterHandler(new LoopHandler() {
+                @Override
+                public void execute(Reactor reactor, Socket socket, Object... args) {
+                    backupVoter.incrementAndGet();
+                    socket.receiveMessage();
+                }
+            })
+            .withActiveHandler(new LoopHandler() {
+                @Override
+                public void execute(Reactor reactor, Socket socket, Object... args) {
+                    backupActive.incrementAndGet();
+                }
+            })
+            .withPassiveHandler(new LoopHandler() {
+                @Override
+                public void execute(Reactor reactor, Socket socket, Object... args) {
+                    backupPassive.incrementAndGet();
+                }
+            })
+            .start();
+    }
+
+    @After
+    public void tearDown() {
+        context1.terminate();
+        context1.close();
+        context2.terminate();
+        context2.close();
+
+        context.close();
+    }
+
+    @Test
+    @Ignore
+    public void testAlive() throws Exception {
+        Thread.sleep(Long.MAX_VALUE);
+    }
+
+    @Test
+    public void testHeartBeat() throws Exception {
+        Thread.sleep(2500);
+
+        assertEquals(1, primaryActive.get());
+        assertEquals(0, primaryPassive.get());
+        assertEquals(1, backupPassive.get());
+        assertEquals(0, backupActive.get());
+    }
+
+    @Test
+    public void testFailover() throws Exception {
+        Thread.sleep(2500);
+        context1.terminate();
+        context1.close();
+        Thread.sleep(250);
+        startPrimary();
+        Thread.sleep(1250);
+
+        assertEquals(1, primaryActive.get());
+        assertEquals(1, primaryPassive.get());
+        assertEquals(1, backupPassive.get());
+        assertEquals(1, backupActive.get());
+    }
+
+    @Test
+    public void testVoter() throws Exception {
+        Thread.sleep(2500);
+        ZInteger buf = new ZInteger();
+        for (int i = 0; i < 10; i++) {
+            buf.put(i).send(socket);
+        }
+
+        Thread.sleep(250);
+        assertEquals(10, primaryVoter.get());
+        assertEquals(0, backupVoter.get());
+    }
+}

--- a/src/test/java/org/zeromq/api/BinaryStarTest.java
+++ b/src/test/java/org/zeromq/api/BinaryStarTest.java
@@ -40,9 +40,9 @@ public class BinaryStarTest {
         context1 = new ManagedContext();
         primary = context1.buildBinaryStar()
             .withMode(BinaryStar.Mode.PRIMARY)
-            .withLocalUrl("tcp://localhost:5555")
+            .withLocalUrl("tcp://*:5555")
             .withRemoteUrl("tcp://localhost:5556")
-            .withVoterSocket("tcp://localhost:5557")
+            .withVoterSocket("tcp://*:5557")
             .withVoterHandler(new LoopHandler() {
                 @Override
                 public void execute(Reactor reactor, Socket socket, Object... args) {
@@ -69,9 +69,9 @@ public class BinaryStarTest {
         context2 = new ManagedContext();
         backup = context2.buildBinaryStar()
             .withMode(BinaryStar.Mode.BACKUP)
-            .withLocalUrl("tcp://localhost:5556")
+            .withLocalUrl("tcp://*:5556")
             .withRemoteUrl("tcp://localhost:5555")
-            .withVoterSocket("tcp://localhost:5558")
+            .withVoterSocket("tcp://*:5558")
             .withVoterHandler(new LoopHandler() {
                 @Override
                 public void execute(Reactor reactor, Socket socket, Object... args) {

--- a/src/test/java/org/zeromq/api/BitsTest.java
+++ b/src/test/java/org/zeromq/api/BitsTest.java
@@ -1,0 +1,87 @@
+package org.zeromq.api;
+
+import static junit.framework.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class BitsTest {
+    @Test
+    public void testPutInt_100() {
+        byte[] buf = new byte[4];
+        Bits.putInt(buf, 100);
+        assertEquals(0, buf[0]);
+        assertEquals(0, buf[1]);
+        assertEquals(0, buf[2]);
+        assertEquals(100, buf[3]);
+    }
+
+    @Test
+    public void testGetInt_100() {
+        byte[] buf = {0, 0, 0, 100};
+
+        int y = Bits.getInt(buf);
+        assertEquals(100, y);
+    }
+
+    @Test
+    public void testPutInt_0x77777777() {
+        byte[] buf = new byte[4];
+        Bits.putInt(buf, 0x77777777);
+        assertEquals(0x77, buf[0]);
+        assertEquals(0x77, buf[1]);
+        assertEquals(0x77, buf[2]);
+        assertEquals(0x77, buf[3]);
+    }
+
+    @Test
+    public void testGetInt_0x77777777() {
+        byte[] buf = {0x77, 0x77, 0x77, 0x77};
+
+        int y = Bits.getInt(buf);
+        assertEquals(0x77777777, y);
+    }
+
+    @Test
+    public void testPutLong_100() {
+        byte[] buf = new byte[8];
+        Bits.putLong(buf, 100);
+        assertEquals(0, buf[0]);
+        assertEquals(0, buf[1]);
+        assertEquals(0, buf[2]);
+        assertEquals(0, buf[3]);
+        assertEquals(0, buf[4]);
+        assertEquals(0, buf[5]);
+        assertEquals(0, buf[6]);
+        assertEquals(100L, buf[7]);
+    }
+
+    @Test
+    public void testGetLong_100() {
+        byte[] buf = {0, 0, 0, 0, 0, 0, 0, 100};
+
+        long y = Bits.getLong(buf);
+        assertEquals(100, y);
+    }
+
+    @Test
+    public void testPutLong_0x7777777777777777() {
+        byte[] buf = new byte[8];
+        Bits.putLong(buf, 0x7777777777777777L);
+        assertEquals(0x77, buf[0]);
+        assertEquals(0x77, buf[1]);
+        assertEquals(0x77, buf[2]);
+        assertEquals(0x77, buf[3]);
+        assertEquals(0x77, buf[4]);
+        assertEquals(0x77, buf[5]);
+        assertEquals(0x77, buf[6]);
+        assertEquals(0x77, buf[7]);
+    }
+
+    @Test
+    public void testGetLong_0x7777777777777777() {
+        byte[] buf = {0x77, 0x77, 0x77, 0x77, 0x77, 0x77, 0x77, 0x77};
+
+        long y = Bits.getLong(buf);
+        assertEquals(0x7777777777777777L, y);
+    }
+}

--- a/src/test/java/org/zeromq/api/DeviceBuilderTest.java
+++ b/src/test/java/org/zeromq/api/DeviceBuilderTest.java
@@ -1,0 +1,126 @@
+package org.zeromq.api;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.zeromq.jzmq.ManagedContext;
+
+public class DeviceBuilderTest {
+    private ManagedContext context;
+
+    @Before
+    public void setUp() {
+        context = new ManagedContext();
+    }
+    
+    @After
+    public void tearDown() throws Exception {
+        context.terminate();
+        context.close();
+    }
+    
+    @Test
+    public void testStreamer() throws Exception {
+        context.buildDevice(DeviceType.STREAMER)
+            .withFrontendUrl("inproc://streamer-frontend")
+            .withBackendUrl("inproc://streamer-backend")
+            .start();
+
+        Socket frontend1 = context.buildSocket(SocketType.PUSH)
+            .connect("inproc://streamer-frontend");
+        Socket frontend2 = context.buildSocket(SocketType.PUSH)
+            .connect("inproc://streamer-frontend");
+        Socket backend1 = context.buildSocket(SocketType.PULL)
+            .connect("inproc://streamer-backend");
+        Socket backend2 = context.buildSocket(SocketType.PULL)
+            .connect("inproc://streamer-backend");
+
+        ZInteger buf = new ZInteger();
+        buf.put(1).send(frontend1);
+        buf.put(2).send(frontend2);
+        buf.put(3).send(frontend2);
+        buf.put(4).send(frontend1);
+
+        assertEquals(1, buf.receive(backend1));
+        assertEquals(2, buf.receive(backend2));
+        assertEquals(3, buf.receive(backend2));
+        assertEquals(4, buf.receive(backend1));
+    }
+
+    @Test
+    public void testForwarder() throws Exception {
+        context.buildDevice(DeviceType.FORWARDER)
+            .withFrontendUrl("inproc://forwarder-frontend")
+            .withBackendUrl("inproc://forwarder-backend")
+            .start();
+
+        Socket frontend1 = context.buildSocket(SocketType.PUB)
+            .connect("inproc://forwarder-frontend");
+        Socket frontend2 = context.buildSocket(SocketType.PUB)
+            .connect("inproc://forwarder-frontend");
+
+        Socket backend1 = context.buildSocket(SocketType.SUB)
+            .asSubscribable().subscribeAll()
+            .connect("inproc://forwarder-backend");
+        Socket backend2 = context.buildSocket(SocketType.SUB)
+            .asSubscribable().subscribeAll()
+            .connect("inproc://forwarder-backend");
+
+        // Give slow joiner some time
+        Thread.sleep(25);
+
+        ZInteger buf = new ZInteger();
+        buf.put(1).send(frontend1);
+        buf.put(2).send(frontend2);
+        buf.put(3).send(frontend2);
+        buf.put(4).send(frontend2);
+
+        assertEquals(1, buf.receive(backend1));
+        assertEquals(1, buf.receive(backend2));
+        assertEquals(2, buf.receive(backend1));
+        assertEquals(2, buf.receive(backend2));
+        assertEquals(3, buf.receive(backend1));
+        assertEquals(3, buf.receive(backend2));
+        assertEquals(4, buf.receive(backend1));
+        assertEquals(4, buf.receive(backend2));
+    }
+
+    @Test
+    public void testQueue() throws Exception {
+        context.buildDevice(DeviceType.QUEUE)
+            .withFrontendUrl("inproc://queue-frontend")
+            .withBackendUrl("inproc://queue-backend")
+            .start();
+
+        Socket frontend1 = context.buildSocket(SocketType.REQ)
+            .connect("inproc://queue-frontend");
+        Socket frontend2 = context.buildSocket(SocketType.REQ)
+            .connect("inproc://queue-frontend");
+
+        Socket backend1 = context.buildSocket(SocketType.REP)
+            .connect("inproc://queue-backend");
+        Socket backend2 = context.buildSocket(SocketType.REP)
+            .connect("inproc://queue-backend");
+
+        ZInteger buf = new ZInteger();
+        buf.put(1).send(frontend1);
+        buf.put(2).send(frontend2);
+        assertEquals(1, buf.receive(backend1));
+        assertEquals(2, buf.receive(backend2));
+        buf.put(3).send(backend1);
+        buf.put(4).send(backend2);
+        assertEquals(3, buf.receive(frontend1));
+        assertEquals(4, buf.receive(frontend2));
+
+        buf.put(5).send(frontend1);
+        buf.put(6).send(frontend2);
+        assertEquals(5, buf.receive(backend1));
+        assertEquals(6, buf.receive(backend2));
+        buf.put(7).send(backend1);
+        buf.put(8).send(backend2);
+        assertEquals(7, buf.receive(frontend1));
+        assertEquals(8, buf.receive(frontend2));
+    }
+}

--- a/src/test/java/org/zeromq/api/DeviceBuilderTest.java
+++ b/src/test/java/org/zeromq/api/DeviceBuilderTest.java
@@ -7,6 +7,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.zeromq.jzmq.ManagedContext;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
 public class DeviceBuilderTest {
     private ManagedContext context;
 
@@ -43,10 +47,12 @@ public class DeviceBuilderTest {
         buf.put(3).send(frontend2);
         buf.put(4).send(frontend1);
 
-        assertEquals(1, buf.receive(backend1));
-        assertEquals(2, buf.receive(backend2));
-        assertEquals(3, buf.receive(backend2));
-        assertEquals(4, buf.receive(backend1));
+        Set<Integer> messages = new HashSet<>();
+        messages.add(buf.receive(backend1));
+        messages.add(buf.receive(backend1));
+        messages.add(buf.receive(backend2));
+        messages.add(buf.receive(backend2));
+        assertEquals(4, messages.size());
     }
 
     @Test

--- a/src/test/java/org/zeromq/api/ProxyTest.java
+++ b/src/test/java/org/zeromq/api/ProxyTest.java
@@ -17,6 +17,7 @@ public class ProxyTest {
 
     @After
     public void tearDown() throws Exception {
+        context.terminate();
         context.close();
     }
 

--- a/src/test/java/org/zeromq/api/QueueTest.java
+++ b/src/test/java/org/zeromq/api/QueueTest.java
@@ -38,8 +38,6 @@ public class QueueTest {
         worker.send("goodbye".getBytes());
         byte[] response2 = client.receive();
         assertArrayEquals("goodbye".getBytes(), response2);
-
-        context.close();
     }
 
 }

--- a/src/test/java/org/zeromq/api/QueueTest.java
+++ b/src/test/java/org/zeromq/api/QueueTest.java
@@ -17,6 +17,7 @@ public class QueueTest {
 
     @After
     public void tearDown() throws Exception {
+        context.terminate();
         context.close();
     }
 

--- a/src/test/java/org/zeromq/api/ReactorTest.java
+++ b/src/test/java/org/zeromq/api/ReactorTest.java
@@ -1,0 +1,174 @@
+package org.zeromq.api;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.zeromq.jzmq.ManagedContext;
+import org.zeromq.jzmq.reactor.ReactorBuilder;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class ReactorTest {
+    private ManagedContext context;
+    private ManagedContext shadow;
+    private Socket in;
+    private Socket out;
+
+    private AtomicInteger safe = new AtomicInteger();
+
+    @Before
+    public void setUp() throws Exception {
+        context = new ManagedContext();
+        shadow = context.shadow();
+        out = shadow.buildSocket(SocketType.PUB).bind("inproc://test");
+        in = shadow.buildSocket(SocketType.SUB).asSubscribable().subscribe("".getBytes()).connect("inproc://test");
+        Thread.sleep(15);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        new Thread() {
+            @Override
+            public void run() {
+                // terminate context without closing sockets to shut down reactor thread
+                context.close();
+            }
+        }.start();
+
+        Thread.sleep(15);
+        shadow.close();
+    }
+
+    @Test
+    public void testTimer() throws Exception {
+        Reactor reactor = context.buildReactor()
+            .withTimer(10, 25, new LoopHandler() {
+                @Override
+                public void execute(Reactor reactor, Socket socket, Object... args) {
+                    safe.incrementAndGet();
+                }
+            })
+            .build();
+
+        reactor.start();
+        Thread.sleep(500);
+        assertEquals(25, safe.get());
+    }
+
+    @Test
+    public void testTimers_1000() throws Exception {
+        LoopHandler handler = new LoopHandler() {
+            @Override
+            public void execute(Reactor reactor, Socket socket, Object... args) {
+                safe.incrementAndGet();
+            }
+        };
+
+        ReactorBuilder builder = context.buildReactor();
+        for (int i = 0; i < 1000; i++) {
+            builder.withTimer(100, (i % 10) + 1, handler);
+        }
+
+        Reactor reactor = builder.build();
+        reactor.start();
+        Thread.sleep(1250);
+        assertEquals(5500, safe.get());
+    }
+    
+    @Test
+    public void testTimers_100000() throws Exception {
+        LoopHandler handler = new LoopHandler() {
+            @Override
+            public void execute(Reactor reactor, Socket socket, Object... args) {
+                safe.incrementAndGet();
+            }
+        };
+
+        ReactorBuilder builder = context.buildReactor();
+        for (int i = 0; i < 100000; i++) {
+            builder.withTimer(100, (i % 10) + 1, handler);
+        }
+
+        Reactor reactor = builder.build();
+        reactor.start();
+        Thread.sleep(1250);
+        assertEquals(550000, safe.get());
+    }
+
+    @Test
+    public void testPoller() throws Exception {
+        Reactor reactor = context.buildReactor()
+            .withInPollable(in, new LoopHandler() {
+                @Override
+                public void execute(Reactor reactor, Socket socket, Object... args) {
+                    assertEquals("Hello", new String(socket.receive()));
+                    safe.incrementAndGet();
+                }
+            })
+            .build();
+
+        reactor.start();
+        out.send("Hello".getBytes());
+        out.send("Hello".getBytes());
+        Thread.sleep(50);
+        out.send("Hello".getBytes());
+        Thread.sleep(250);
+        assertEquals(3, safe.get());
+    }
+
+    @Test
+    public void testPollers_1000() throws Exception {
+        ReactorBuilder builder = context.buildReactor();
+        LoopHandler handler = new LoopHandler() {
+            @Override
+            public void execute(Reactor reactor, Socket socket, Object... args) {
+                assertEquals("Hello", new String(socket.receive()));
+                safe.incrementAndGet();
+            }
+        };
+
+        for (int i = 0; i < 1000; i++) {
+            Socket s = shadow.buildSocket(SocketType.SUB)
+                    .asSubscribable().subscribe("".getBytes())
+                    .connect("inproc://test");
+            builder.withInPollable(s, handler);
+        }
+
+        Reactor reactor = builder.build();
+        reactor.start();
+        out.send("Hello".getBytes());
+        out.send("Hello".getBytes());
+        Thread.sleep(50);
+        out.send("Hello".getBytes());
+        Thread.sleep(250);
+        assertEquals(3000, safe.get());
+    }
+
+    @Test
+    public void testMultiple() throws Exception {
+        Reactor reactor = context.buildReactor()
+            .withTimer(10, 25, new LoopHandler() {
+                @Override
+                public void execute(Reactor reactor, Socket socket, Object... args) {
+                    safe.incrementAndGet();
+                }
+            })
+            .withInPollable(in, new LoopHandler() {
+                @Override
+                public void execute(Reactor reactor, Socket socket, Object... args) {
+                    assertEquals("Hello", new String(socket.receive()));
+                    safe.incrementAndGet();
+                }
+            })
+            .build();
+
+        reactor.start();
+        out.send("Hello".getBytes());
+        out.send("Hello".getBytes());
+        out.send("Hello".getBytes());
+        Thread.sleep(500);
+        assertEquals(28, safe.get());
+    }
+}

--- a/src/test/java/org/zeromq/api/ReactorTest.java
+++ b/src/test/java/org/zeromq/api/ReactorTest.java
@@ -36,7 +36,7 @@ public class ReactorTest {
         Reactor reactor = context.buildReactor()
             .withTimer(10, 25, new LoopHandler() {
                 @Override
-                public void execute(Reactor reactor, Socket socket, Object... args) {
+                public void execute(Reactor reactor, Pollable pollable, Object... args) {
                     safe.incrementAndGet();
                 }
             })
@@ -51,7 +51,7 @@ public class ReactorTest {
     public void testTimers_1000() throws Exception {
         LoopHandler handler = new LoopHandler() {
             @Override
-            public void execute(Reactor reactor, Socket socket, Object... args) {
+            public void execute(Reactor reactor, Pollable pollable, Object... args) {
                 safe.incrementAndGet();
             }
         };
@@ -71,7 +71,7 @@ public class ReactorTest {
     public void testTimers_100000() throws Exception {
         LoopHandler handler = new LoopHandler() {
             @Override
-            public void execute(Reactor reactor, Socket socket, Object... args) {
+            public void execute(Reactor reactor, Pollable pollable, Object... args) {
                 safe.incrementAndGet();
             }
         };
@@ -92,8 +92,8 @@ public class ReactorTest {
         Reactor reactor = context.buildReactor()
             .withInPollable(in, new LoopHandler() {
                 @Override
-                public void execute(Reactor reactor, Socket socket, Object... args) {
-                    assertEquals("Hello", new String(socket.receive()));
+                public void execute(Reactor reactor, Pollable pollable, Object... args) {
+                    assertEquals("Hello", new String(pollable.getSocket().receive()));
                     safe.incrementAndGet();
                 }
             })
@@ -113,8 +113,8 @@ public class ReactorTest {
         ReactorBuilder builder = context.buildReactor();
         LoopHandler handler = new LoopHandler() {
             @Override
-            public void execute(Reactor reactor, Socket socket, Object... args) {
-                assertEquals("Hello", new String(socket.receive()));
+            public void execute(Reactor reactor, Pollable pollable, Object... args) {
+                assertEquals("Hello", new String(pollable.getSocket().receive()));
                 safe.incrementAndGet();
             }
         };
@@ -141,14 +141,14 @@ public class ReactorTest {
         Reactor reactor = context.buildReactor()
             .withTimer(10, 25, new LoopHandler() {
                 @Override
-                public void execute(Reactor reactor, Socket socket, Object... args) {
+                public void execute(Reactor reactor, Pollable pollable, Object... args) {
                     safe.incrementAndGet();
                 }
             })
             .withInPollable(in, new LoopHandler() {
                 @Override
-                public void execute(Reactor reactor, Socket socket, Object... args) {
-                    assertEquals("Hello", new String(socket.receive()));
+                public void execute(Reactor reactor, Pollable pollable, Object... args) {
+                    assertEquals("Hello", new String(pollable.getSocket().receive()));
                     safe.incrementAndGet();
                 }
             })

--- a/src/test/java/org/zeromq/api/SocketTest.java
+++ b/src/test/java/org/zeromq/api/SocketTest.java
@@ -26,7 +26,7 @@ public class SocketTest {
         context.close();
     }
     
-    @Test
+    @Test(expected=InvalidSocketException.class)
     public void testClosedSocket() {
         Context shadow = context.shadow();
         Socket pub = shadow.buildSocket(SocketType.PUB)
@@ -40,12 +40,7 @@ public class SocketTest {
         assertEquals("hello", new String(sub.receive()));
         
         shadow.close();
-        try {
-            pub.send("hello, world".getBytes());
-        } catch (InvalidSocketException ignored) {
-            // Expected behavior with jzmq
-            // Nothing is thrown in jeromq
-        }
+        pub.send("hello, world".getBytes());
     }
     
     @Test(timeout=1000)

--- a/src/test/java/org/zeromq/client/BackupStar.java
+++ b/src/test/java/org/zeromq/client/BackupStar.java
@@ -5,7 +5,7 @@ import org.zeromq.api.Pollable;
 import org.zeromq.api.Reactor;
 import org.zeromq.api.SocketType;
 import org.zeromq.jzmq.ManagedContext;
-import org.zeromq.jzmq.bstar.BinaryStarImpl;
+import org.zeromq.jzmq.bstar.BinaryStarReactorImpl;
 
 import java.util.Arrays;
 
@@ -30,7 +30,7 @@ public class BackupStar {
         }
 
         ManagedContext context = new ManagedContext();
-        BinaryStarImpl binaryStar = new BinaryStarImpl(context, BinaryStarImpl.Mode.BACKUP, local, remote);
+        BinaryStarReactorImpl binaryStar = new BinaryStarReactorImpl(context, BinaryStarReactorImpl.Mode.BACKUP, local, remote);
         binaryStar.registerVoterSocket(context.buildSocket(SocketType.PULL).bind(voter));
         binaryStar.setVoterHandler(new MyHandler(), "backup-voter");
         binaryStar.setActiveHandler(new MyHandler(), "backup-active");

--- a/src/test/java/org/zeromq/client/BackupStar.java
+++ b/src/test/java/org/zeromq/client/BackupStar.java
@@ -1,0 +1,55 @@
+package org.zeromq.client;
+
+import org.zeromq.api.LoopHandler;
+import org.zeromq.api.Reactor;
+import org.zeromq.api.Socket;
+import org.zeromq.api.SocketType;
+import org.zeromq.jzmq.ManagedContext;
+import org.zeromq.jzmq.bstar.BinaryStarImpl;
+
+import java.util.Arrays;
+
+public class BackupStar {
+    /**
+     * @param args
+     */
+    public static void main(String[] args) {
+        String local = "tcp://localhost:5556";
+        if (args.length >= 1) {
+            local = args[0];
+        }
+
+        String remote = "tcp://localhost:5555";
+        if (args.length >= 2) {
+            remote = args[1];
+        }
+
+        String voter = "tcp://localhost:5558";
+        if (args.length >= 3) {
+            remote = args[2];
+        }
+
+        ManagedContext context = new ManagedContext();
+        BinaryStarImpl binaryStar = new BinaryStarImpl(context, BinaryStarImpl.Mode.BACKUP, local, remote);
+        binaryStar.registerVoterSocket(context.buildSocket(SocketType.PULL).bind(voter));
+        binaryStar.setVoterHandler(new MyHandler(), "backup-voter");
+        binaryStar.setActiveHandler(new MyHandler(), "backup-active");
+        binaryStar.setPassiveHandler(new MyHandler(), "backup-passive");
+        binaryStar.start();
+
+        try {
+            Thread.sleep(Long.MAX_VALUE);
+        } catch (InterruptedException ignored) {
+        }
+
+        context.terminate();
+        context.close();
+    }
+
+    public static class MyHandler implements LoopHandler {
+        @Override
+        public void execute(Reactor reactor, Socket socket, Object... args) {
+            System.out.println(Arrays.asList(args).toString());
+        }
+    }
+}

--- a/src/test/java/org/zeromq/client/BackupStar.java
+++ b/src/test/java/org/zeromq/client/BackupStar.java
@@ -1,8 +1,8 @@
 package org.zeromq.client;
 
 import org.zeromq.api.LoopHandler;
+import org.zeromq.api.Pollable;
 import org.zeromq.api.Reactor;
-import org.zeromq.api.Socket;
 import org.zeromq.api.SocketType;
 import org.zeromq.jzmq.ManagedContext;
 import org.zeromq.jzmq.bstar.BinaryStarImpl;
@@ -48,7 +48,7 @@ public class BackupStar {
 
     public static class MyHandler implements LoopHandler {
         @Override
-        public void execute(Reactor reactor, Socket socket, Object... args) {
+        public void execute(Reactor reactor, Pollable pollable, Object... args) {
             System.out.println(Arrays.asList(args).toString());
         }
     }

--- a/src/test/java/org/zeromq/client/PrimaryStar.java
+++ b/src/test/java/org/zeromq/client/PrimaryStar.java
@@ -5,7 +5,7 @@ import org.zeromq.api.Pollable;
 import org.zeromq.api.Reactor;
 import org.zeromq.api.SocketType;
 import org.zeromq.jzmq.ManagedContext;
-import org.zeromq.jzmq.bstar.BinaryStarImpl;
+import org.zeromq.jzmq.bstar.BinaryStarReactorImpl;
 
 import java.util.Arrays;
 
@@ -30,7 +30,7 @@ public class PrimaryStar {
         }
 
         ManagedContext context = new ManagedContext();
-        BinaryStarImpl binaryStar = new BinaryStarImpl(context, BinaryStarImpl.Mode.PRIMARY, local, remote);
+        BinaryStarReactorImpl binaryStar = new BinaryStarReactorImpl(context, BinaryStarReactorImpl.Mode.PRIMARY, local, remote);
         binaryStar.registerVoterSocket(context.buildSocket(SocketType.PULL).bind(voter));
         binaryStar.setVoterHandler(new MyHandler(), "primary-voter");
         binaryStar.setActiveHandler(new MyHandler(), "primary-active");

--- a/src/test/java/org/zeromq/client/PrimaryStar.java
+++ b/src/test/java/org/zeromq/client/PrimaryStar.java
@@ -1,8 +1,8 @@
 package org.zeromq.client;
 
 import org.zeromq.api.LoopHandler;
+import org.zeromq.api.Pollable;
 import org.zeromq.api.Reactor;
-import org.zeromq.api.Socket;
 import org.zeromq.api.SocketType;
 import org.zeromq.jzmq.ManagedContext;
 import org.zeromq.jzmq.bstar.BinaryStarImpl;
@@ -48,7 +48,7 @@ public class PrimaryStar {
 
     public static class MyHandler implements LoopHandler {
         @Override
-        public void execute(Reactor reactor, Socket socket, Object... args) {
+        public void execute(Reactor reactor, Pollable pollable, Object... args) {
             System.out.println(Arrays.asList(args).toString());
         }
     }

--- a/src/test/java/org/zeromq/client/PrimaryStar.java
+++ b/src/test/java/org/zeromq/client/PrimaryStar.java
@@ -1,0 +1,55 @@
+package org.zeromq.client;
+
+import org.zeromq.api.LoopHandler;
+import org.zeromq.api.Reactor;
+import org.zeromq.api.Socket;
+import org.zeromq.api.SocketType;
+import org.zeromq.jzmq.ManagedContext;
+import org.zeromq.jzmq.bstar.BinaryStarImpl;
+
+import java.util.Arrays;
+
+public class PrimaryStar {
+    /**
+     * @param args
+     */
+    public static void main(String[] args) {
+        String local = "tcp://localhost:5555";
+        if (args.length >= 1) {
+            local = args[0];
+        }
+
+        String remote = "tcp://localhost:5556";
+        if (args.length >= 2) {
+            remote = args[1];
+        }
+
+        String voter = "tcp://localhost:5557";
+        if (args.length >= 3) {
+            remote = args[2];
+        }
+
+        ManagedContext context = new ManagedContext();
+        BinaryStarImpl binaryStar = new BinaryStarImpl(context, BinaryStarImpl.Mode.PRIMARY, local, remote);
+        binaryStar.registerVoterSocket(context.buildSocket(SocketType.PULL).bind(voter));
+        binaryStar.setVoterHandler(new MyHandler(), "primary-voter");
+        binaryStar.setActiveHandler(new MyHandler(), "primary-active");
+        binaryStar.setPassiveHandler(new MyHandler(), "primary-passive");
+        binaryStar.start();
+
+        try {
+            Thread.sleep(Long.MAX_VALUE);
+        } catch (InterruptedException ignored) {
+        }
+
+        context.terminate();
+        context.close();
+    }
+
+    public static class MyHandler implements LoopHandler {
+        @Override
+        public void execute(Reactor reactor, Socket socket, Object... args) {
+            System.out.println(Arrays.asList(args).toString());
+        }
+    }
+}


### PR DESCRIPTION
Part 1 of adding support for the Clone Pattern (clustered hashmap) to the library:

* Added terminate method to Context with implementation to asynchronously terminate (attempting to easily abort pollers)
* Added ZInteger and ZLong helpers for messaging numbers
* Added event-driven Reactor
* Added Binary Star Reactor

Part 2:

* Added subscribeAll method to SubSocketBuilder
* Added BeaconReactor
* Changed PollListener API to accept Pollable
* Added BinaryStarClient background agent and socket builder
* Various improvements and test fixes