### PR TITLE
Problem: Missing no-context API for jzmq-api

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ language: java
 script: mvn test
 
 jdk:
- - openjdk7
+ - oraclejdk7

--- a/src/main/java/org/zeromq/ContextFactory.java
+++ b/src/main/java/org/zeromq/ContextFactory.java
@@ -1,16 +1,62 @@
 package org.zeromq;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.zeromq.api.Context;
 import org.zeromq.jzmq.ManagedContext;
 
+/**
+ * Factory containing utility methods for managing instances of a ØMQ Context.
+ */
 public class ContextFactory {
+
+    /** Default io threads, to be customized by the application, or set via property. */
+    public static int DEFAULT_IO_THREADS = Integer.parseInt(
+        System.getProperty("zmq.default.io.threads", "1"));
+
+    private static final Logger log = LoggerFactory.getLogger(ContextFactory.class);
+
+    /**
+     * Protected constructor.
+     */
     private ContextFactory() {
     }
 
+    /**
+     * Create a new ØMQ Context.
+     * 
+     * @param ioThreads The number of background I/O threads to use
+     * @return A new ØMQ Context
+     */
     public static Context createContext(int ioThreads) {
         if (ioThreads < 0) {
             throw new IllegalArgumentException("ioThreads must be positive");
         }
         return new ManagedContext(ZMQ.context(ioThreads));
+    }
+
+    /**
+     * Retrieve the singleton instance of a ØMQ Context.
+     * 
+     * @return A singleton ØMQ Context
+     */
+    public static Context context() {
+        return ContextHolder.INSTANCE;
+    }
+
+    /**
+     * Lazily initialized singleton.
+     */
+    private static class ContextHolder {
+        private static Context INSTANCE = createContext(DEFAULT_IO_THREADS);
+        static {
+            Runtime.getRuntime().addShutdownHook(new Thread() {
+                @Override
+                public void run() {
+                    log.debug("closing singleton context...");
+                    INSTANCE.close();
+                }
+            });
+        }
     }
 }

--- a/src/main/java/org/zeromq/Patterns.java
+++ b/src/main/java/org/zeromq/Patterns.java
@@ -1,0 +1,47 @@
+package org.zeromq;
+
+import org.zeromq.jzmq.beacon.BeaconReactorBuilder;
+import org.zeromq.jzmq.bstar.BinaryStarReactorBuilder;
+import org.zeromq.jzmq.bstar.BinaryStarSocketBuilder;
+
+/**
+ * Class containing utility methods for creating objects for different patterns
+ * without using a ØMQ Context directly.
+ */
+public class Patterns {
+    /**
+     * Protected constructor.
+     */
+    private Patterns() {
+    }
+
+    /**
+     * Create a new BinaryStarReactor, which will create one half of an HA-pair
+     * with event-driven polling of a client Socket.
+     * 
+     * @return A builder for constructing a BinaryStarReactor
+     */
+    public static BinaryStarReactorBuilder buildBinaryStarReactor() {
+        return ContextFactory.context().buildBinaryStarReactor();
+    }
+
+    /**
+     * Create a ØMQ Socket, backed by a background agent that is connecting
+     * to a BinaryStarReactor HA-pair.
+     * 
+     * @return A builder for constructing connecting a BinaryStarReactor client Socket
+     */
+    public static BinaryStarSocketBuilder buildBinaryStarSocket() {
+        return ContextFactory.context().buildBinaryStarSocket();
+    }
+
+    /**
+     * Create a new BeaconReactor, which will send and receive UDP beacons
+     * on a broadcast address, with event-driven handling of received beacons.
+     * 
+     * @return A builder for constructing a BeaconReactor
+     */
+    public static BeaconReactorBuilder buildBeaconReactor() {
+        return ContextFactory.context().buildBeaconReactor();
+    }
+}

--- a/src/main/java/org/zeromq/Sockets.java
+++ b/src/main/java/org/zeromq/Sockets.java
@@ -1,0 +1,266 @@
+package org.zeromq;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+
+import org.zeromq.api.Backgroundable;
+import org.zeromq.api.DeviceType;
+import org.zeromq.api.LoopHandler;
+import org.zeromq.api.PollListener;
+import org.zeromq.api.Poller;
+import org.zeromq.api.Reactor;
+import org.zeromq.api.Socket;
+import org.zeromq.api.SocketType;
+import org.zeromq.jzmq.poll.PollerBuilder;
+import org.zeromq.jzmq.reactor.ReactorBuilder;
+import org.zeromq.jzmq.sockets.SocketBuilder;
+
+import java.nio.channels.SelectableChannel;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Class containing utility methods for creating ØMQ Sockets and other related
+ * objects without using a ØMQ Context directly.
+ */
+public class Sockets {
+    /**
+     * Protected constructor.
+     */
+    private Sockets() {
+    }
+
+    /**
+     * Create a builder capable of constructing ØMQ Sockets of the given socket type.
+     * 
+     * @param socketType The socket type
+     * @return A builder for constructing ØMQ Sockets
+     */
+    public static SocketBuilder buildSocket(SocketType socketType) {
+        return ContextFactory.context().buildSocket(socketType);
+    }
+
+    /**
+     * Create a ØMQ Socket and connect it to a given url.
+     * 
+     * @param socketType The socket type    
+     * @param url The url to connect to
+     * @return A ØMQ Socket
+     */
+    public static Socket connect(SocketType socketType, String url) {
+        return buildSocket(socketType).connect(url);
+    }
+
+    /**
+     * Create a ØMQ Socket and bind it to a given url.
+     * 
+     * @param socketType The socket type
+     * @param url The url to bind to
+     * @return A ØMQ Socket
+     */
+    public static Socket bind(SocketType socketType, String url) {
+        return buildSocket(socketType).bind(url);
+    }
+
+    /**
+     * Create a builder capable of constructing a ØMQ Poller.
+     * 
+     * @return A builder for constructing a ØMQ Poller
+     */
+    public static PollerBuilder buildPoller() {
+        return ContextFactory.context().buildPoller();
+    }
+
+    /**
+     * Create a ØMQ Poller with a single PollListener which handles incoming
+     * messages from the given ØMQ Sockets.
+     * 
+     * @param listener A listener for handling incoming messages
+     * @param sockets One or more ØMQ Sockets
+     * @return A new ØMQ Poller
+     */
+    public static Poller newPoller(PollListener listener, Socket... sockets) {
+        return newPoller(listener, asList(sockets), null);
+    }
+
+    /**
+     * Create a ØMQ Poller with a single PollListener which handles incoming
+     * messages from the given SelectableChannels.
+     * 
+     * @param listener A listener for handling incoming messages
+     * @param channels One or more channels that can be multiplexed with ØMQ Sockets
+     * @return A new ØMQ Poller
+     */
+    public static Poller newPoller(PollListener listener, SelectableChannel... channels) {
+        return newPoller(listener, null, asList(channels));
+    }
+
+    /**
+     * Create a ØMQ Poller with a single PollListener which handles incoming
+     * messages from the given ØMQ Socket and SelectableChannel.
+     * 
+     * @param listener A listener for handling incoming messages
+     * @param socket A ØMQ Socket
+     * @param channel A selectable channel that can be multiplexed with ØMQ Sockets
+     * @return A new ØMQ Poller
+     */
+    public static Poller newPoller(PollListener listener, Socket socket, SelectableChannel channel) {
+        return newPoller(listener, singletonList(socket), singletonList(channel));
+    }
+
+    /**
+     * Create a ØMQ Poller with a single PollListener which handles incoming
+     * messages from the given ØMQ Sockets and SelectableChannels.
+     * 
+     * @param listener A listener for handling incoming messages
+     * @param sockets One or more ØMQ Sockets
+     * @param channels One or more channels that can be multiplexed with ØMQ Sockets
+     * @return A new ØMQ Poller
+     */
+    public static Poller newPoller(PollListener listener, List<Socket> sockets, List<SelectableChannel> channels) {
+        PollerBuilder builder = buildPoller();
+        if (sockets != null) {
+            for (Socket socket : sockets) {
+                builder.withInPollable(socket, listener);
+            }
+        }
+        if (channels != null) {
+            for (SelectableChannel channel : channels) {
+                builder.withInPollable(channel, listener);
+            }
+        }
+
+        return builder.build();
+    }
+
+    /**
+     * Create a builder capable of constructing a ØMQ Reactor.
+     * 
+     * @return A builder for constructing a ØMQ Reactor
+     */
+    public static ReactorBuilder buildReactor() {
+        return ContextFactory.context().buildReactor();
+    }
+
+    /**
+     * Create a ØMQ Reactor with a single LoopHandler which handles incoming
+     * messages from the given ØMQ Sockets.
+     * 
+     * @param handler A handler for executing event-driven polling of Sockets
+     * @param sockets One or more ØMQ Sockets
+     * @return A new ØMQ Reactor
+     */
+    public static Reactor newReactor(LoopHandler handler, Socket... sockets) {
+        return newReactor(handler, asList(sockets), null);
+    }
+
+    /**
+     * Create a ØMQ Reactor with a single LoopHandler which handles incoming
+     * messages from the given SelectableChannels.
+     * 
+     * @param handler A handler for executing event-driven polling of Sockets
+     * @param channels One or more channels that can be multiplexed with ØMQ Sockets
+     * @return A new ØMQ Reactor
+     */
+    public static Reactor newReactor(LoopHandler handler, SelectableChannel... channels) {
+        return newReactor(handler, null, asList(channels));
+    }
+
+    /**
+     * Create a ØMQ Reactor with a single LoopHandler which handles incoming
+     * messages from the given ØMQ Socket and SelectableChannel.
+     * 
+     * @param handler A handler for executing event-driven polling of Sockets
+     * @param socket A ØMQ Socket
+     * @param channel A selectable channel that can be multiplexed with ØMQ Sockets
+     * @return A new ØMQ Reactor
+     */
+    public static Reactor newReactor(LoopHandler handler, Socket socket, SelectableChannel channel) {
+        return newReactor(handler, singletonList(socket), singletonList(channel));
+    }
+
+    /**
+     * Create a ØMQ Reactor with a single LoopHandler which initially handles
+     * a repeating timer with the given interval.
+     *
+     * @param handler A handler for executing event-driven polling of Sockets
+     * @param interval The initial and subsequet delay for a repeating timer event
+     * @param unit The time unit for the timer interval
+     * @return A new ØMQ Reactor
+     */
+    public static Reactor newReactor(LoopHandler handler, long interval, TimeUnit unit) {
+        return ContextFactory.context().buildReactor()
+            .withTimerRepeating(interval, unit, handler)
+            .build();
+    }
+
+    /**
+     * Create a ØMQ Reactor with a single LoopHandler which handles incoming
+     * messages from the given ØMQ Sockets and SelectableChannels.
+     * 
+     * @param handler A handler for executing event-driven polling of Sockets
+     * @param sockets One or more ØMQ Sockets
+     * @param channels One or more channels that can be multiplexed with ØMQ Sockets
+     * @return A new ØMQ Poller
+     */
+    public static Reactor newReactor(LoopHandler handler, List<Socket> sockets, List<SelectableChannel> channels) {
+        ReactorBuilder builder = buildReactor();
+        if (sockets != null) {
+            for (Socket socket : sockets) {
+                builder.withInPollable(socket, handler);
+            }
+        }
+        if (channels != null) {
+            for (SelectableChannel channel : channels) {
+                builder.withInPollable(channel, handler);
+            }
+        }
+
+        return builder.build();
+    }
+
+    /**
+     * Start a ØMQ Device of the given type, which will run in the background to
+     * bridge two networks together.
+     * 
+     * @param deviceType The device type, specifying the pattern to use
+     */
+    public static void start(DeviceType deviceType, String frontendUrl, String backendUrl) {
+        ContextFactory.context().buildDevice(deviceType)
+            .withFrontendUrl(frontendUrl)
+            .withBackendUrl(backendUrl)
+            .start();
+    }
+
+    /**
+     * Create a ØMQ proxy and start it up.  Returns when the context is closed.
+     * 
+     * @param frontEnd The front-end socket which will be proxied to/from the back-end
+     * @param backEnd The back-end socket which will be proxied to/from the front-end
+     */
+    public static void proxy(Socket frontEnd, Socket backEnd) {
+        ContextFactory.context().proxy(frontEnd, backEnd);
+    }
+
+    /**
+     * Create a ØMQ proxy and start it up on another thread that exits when the
+     * context is closed.
+     * 
+     * @param frontEnd The front-end socket which will be proxied to/from the back-end
+     * @param backEnd The back-end socket which will be proxied to/from the front-end
+     */
+    public static void forward(Socket frontEnd, Socket backEnd) {
+        ContextFactory.context().forward(frontEnd, backEnd);
+    }
+
+    /**
+     * Run a background thread with an inproc PAIR socket for communication.
+     * 
+     * @param backgroundable The task to be performed on the background thread
+     * @param args Optional arguments for the task
+     * @return The inproc PAIR socket for communicating with the background thread
+     */
+    public static Socket fork(Backgroundable backgroundable, Object... args) {
+        return ContextFactory.context().fork(backgroundable, args);
+    }
+}

--- a/src/main/java/org/zeromq/api/Context.java
+++ b/src/main/java/org/zeromq/api/Context.java
@@ -103,7 +103,7 @@ public interface Context extends Closeable {
     Pollable newPollable(SelectableChannel channel, PollerType... options);
 
     /**
-     * Create a ZMQ proxy and start it up.  Returns when the context is closed.
+     * Create a ØMQ proxy and start it up.  Returns when the context is closed.
      * 
      * @param frontEnd The front-end socket which will be proxied to/from the back-end
      * @param backEnd The back-end socket which will be proxied to/from the front-end
@@ -111,8 +111,8 @@ public interface Context extends Closeable {
     void proxy(Socket frontEnd, Socket backEnd);
 
     /**
-     * Create a ZMQ proxy and start it up on another thread that exits when the context
-     * is closed.
+     * Create a ØMQ proxy and start it up on another thread that exits when the
+     * context is closed.
      *
      * @param frontEnd The front-end socket which will be proxied to/from the back-end
      * @param backEnd The back-end socket which will be proxied to/from the front-end

--- a/src/main/java/org/zeromq/jzmq/reactor/ReactorBuilder.java
+++ b/src/main/java/org/zeromq/jzmq/reactor/ReactorBuilder.java
@@ -8,6 +8,7 @@ import org.zeromq.api.Socket;
 import org.zeromq.jzmq.ManagedContext;
 
 import java.nio.channels.SelectableChannel;
+import java.util.concurrent.TimeUnit;
 
 public class ReactorBuilder {
     private final ManagedContext context;
@@ -84,8 +85,16 @@ public class ReactorBuilder {
         return withTimer(initialDelay, 1, handler, args);
     }
 
+    public ReactorBuilder withTimerOnce(long initialDelay, TimeUnit unit, LoopHandler handler, Object... args) {
+        return withTimer(unit.toMillis(initialDelay), 1, handler, args);
+    }
+
     public ReactorBuilder withTimerRepeating(long initialDelay, LoopHandler handler, Object... args) {
         return withTimer(initialDelay, -1, handler, args);
+    }
+
+    public ReactorBuilder withTimerRepeating(long initialDelay, TimeUnit unit, LoopHandler handler, Object... args) {
+        return withTimer(unit.toMillis(initialDelay), -1, handler, args);
     }
 
     public Reactor build() {

--- a/src/test/java/org/zeromq/api/DeviceBuilderTest.java
+++ b/src/test/java/org/zeromq/api/DeviceBuilderTest.java
@@ -107,22 +107,17 @@ public class DeviceBuilderTest {
         Socket backend2 = context.buildSocket(SocketType.REP)
             .connect("inproc://queue-backend");
 
+        Set<Integer> messages = new HashSet<>();
         frontend1.send(new Message(1));
         frontend2.send(new Message(2));
-        assertEquals(1, backend1.receiveMessage().popInt());
-        assertEquals(2, backend2.receiveMessage().popInt());
+
+        messages.add(backend1.receiveMessage().popInt());
+        messages.add(backend2.receiveMessage().popInt());
+
         backend1.send(new Message(3));
         backend2.send(new Message(4));
-        assertEquals(3, frontend1.receiveMessage().popInt());
-        assertEquals(4, frontend2.receiveMessage().popInt());
-
-        frontend1.send(new Message(5));
-        frontend2.send(new Message(6));
-        assertEquals(5, backend1.receiveMessage().popInt());
-        assertEquals(6, backend2.receiveMessage().popInt());
-        backend1.send(new Message(7));
-        backend2.send(new Message(8));
-        assertEquals(7, frontend1.receiveMessage().popInt());
-        assertEquals(8, frontend2.receiveMessage().popInt());
+        messages.add(frontend1.receiveMessage().popInt());
+        messages.add(frontend2.receiveMessage().popInt());
+        assertEquals(4, messages.size());
     }
 }

--- a/src/test/java/org/zeromq/api/ForkTest.java
+++ b/src/test/java/org/zeromq/api/ForkTest.java
@@ -11,81 +11,64 @@ import org.junit.Test;
 import org.zeromq.ContextFactory;
 
 public class ForkTest {
-
     private Context context;
-    private volatile boolean shutDown = false;
-    
+
     @Before
     public void setUp() {
-        this.context = ContextFactory.createContext(1);
+        context = ContextFactory.createContext(1);
     }
-    
+
     @After
     public void tearDown() {
-        context.close();
     }
-    
+
     @Test
     public void testFork() throws Exception {
         Socket pipe = context.fork(new Backgroundable() {
             @Override
             public void run(Context context, Socket pipe, Object... args) {
-                while (!shutDown) {
-                    pipe.send("hello".getBytes());
-                    assertEquals("hi", new String(pipe.receive()));
-                }
+                pipe.send("hello".getBytes());
+                assertEquals("hi", new String(pipe.receive()));
             }
-            
+
             @Override
             public void onClose() {
                 // TODO Auto-generated method stub
-                
+
             }
         });
-        
+
         assertEquals("hello", new String(pipe.receive()));
         pipe.send("hi".getBytes());
-        assertEquals("hello", new String(pipe.receive()));
-        
-        shutDown = true;
-        pipe.send("hi".getBytes());
-        
+
         context.close();
     }
-    
+
     @Test
     public void testBackgroundable() throws Exception {
         final AtomicBoolean closed = new AtomicBoolean(false);
         Socket req = context.buildSocket(SocketType.REQ)
             .bind("inproc://background-test");
-        
+
         // background thread will handle this socket
-        /* Socket rep = */
         context.buildSocket(SocketType.REP)
             .withBackgroundable(new Backgroundable() {
                 @Override
                 public void run(Context context, Socket socket, Object... args) {
-                    while (!shutDown) {
-                        assertEquals("hello", new String(socket.receive()));
-                        socket.send("hello, world".getBytes());
-                    }
-                    
+                    assertEquals("hello", new String(socket.receive()));
+                    socket.send("hello, world".getBytes());
                 }
-                
+
                 @Override
                 public void onClose() {
                     closed.set(true);
                 }
             })
             .connect("inproc://background-test");
-        
+
         req.send("hello".getBytes());
         assertEquals("hello, world", new String(req.receive()));
-        
-        shutDown = true;
-        req.send("hello".getBytes());
-        assertEquals("hello, world", new String(req.receive()));
-        
+
         context.close();
         assertTrue(closed.get());
     }

--- a/src/test/java/org/zeromq/api/SocketsTest.java
+++ b/src/test/java/org/zeromq/api/SocketsTest.java
@@ -1,0 +1,44 @@
+package org.zeromq.api;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.zeromq.Sockets;
+
+public class SocketsTest {
+    @Test
+    public void testPushPull() {
+        try (Socket push = Sockets.bind(SocketType.PUSH, "tcp://*:5991");
+             Socket pull = Sockets.connect(SocketType.PULL, "tcp://127.0.0.1:5991")) {
+            push.send(new Message("Hello"));
+            assertEquals("Hello", pull.receiveMessage().popString());
+        }
+    }
+
+    @Test
+    public void testPubSub() throws Exception {
+        try (Socket pub = Sockets.bind(SocketType.PUB, "tcp://*:5992");
+             Socket sub = Sockets.buildSocket(SocketType.SUB)
+                 .asSubscribable().subscribeAll()
+                 .connect("tcp://127.0.0.1:5992")) {
+            Thread.sleep(250);
+            pub.send(new Message("Hello"));
+
+            assertEquals("Hello", sub.receiveMessage().popString());
+        }
+    }
+
+    @Test
+    public void testReqRepWithPoller() {
+        try (Socket req = Sockets.bind(SocketType.REQ, "tcp://*:5993");
+             Socket rep = Sockets.connect(SocketType.REP, "tcp://127.0.0.1:5993")) {
+            Poller poller = Sockets.newPoller(new PollAdapter(), req, rep);
+            req.send(new Message("World"));
+            poller.poll();
+            rep.send(new Message("Hello, " + rep.receiveMessage().popString()));
+            poller.poll();
+
+            assertEquals("Hello, World", req.receiveMessage().popString());
+        }
+    }
+}


### PR DESCRIPTION
**Solution:** Add a no-context API and helper methods to create ØMQ Sockets and other related objects without using a ØMQ Context directly.