### PR TITLE
Multiple code improvements - squid:S1213, squid:S1210, squid:S1873, squid:S2386, squid:UselessParenthesesCheck, squid:S1155

### DIFF
--- a/src/main/java/org/zeromq/api/Message.java
+++ b/src/main/java/org/zeromq/api/Message.java
@@ -19,7 +19,7 @@ public class Message implements Iterable<Message.Frame> {
             System.getProperty("zmq.default.charset", "UTF-8"));
 
     /** An empty byte array. */
-    public static final byte[] EMPTY_FRAME_DATA = new byte[0];
+    private static final byte[] EMPTY_FRAME_DATA = new byte[0];
 
     /** A handy reference to an empty {@link Frame}. */
     public static final Frame EMPTY_FRAME = new Frame(EMPTY_FRAME_DATA);
@@ -255,7 +255,7 @@ public class Message implements Iterable<Message.Frame> {
      * @return true if the message is empty, false otherwise
      */
     public boolean isEmpty() {
-        return (frames.size() == 0);
+        return frames.isEmpty();
     }
 
     /**
@@ -471,7 +471,7 @@ public class Message implements Iterable<Message.Frame> {
         }
 
         public boolean isBlank() {
-            return (buffer.capacity() == 0);
+            return buffer.capacity() == 0;
         }
 
         public static Frame wrap(byte value) {

--- a/src/main/java/org/zeromq/api/exception/ZMQExceptions.java
+++ b/src/main/java/org/zeromq/api/exception/ZMQExceptions.java
@@ -33,7 +33,7 @@ public class ZMQExceptions {
      * @return true if the exception indicates ETERM, false otherwise
      */
     public static boolean isContextTerminated(ZMQException thrown) {
-        return (thrown.getErrorCode() == ZMQ.Error.ETERM.getCode());
+        return thrown.getErrorCode() == ZMQ.Error.ETERM.getCode();
     }
 
     /**
@@ -43,7 +43,7 @@ public class ZMQExceptions {
      * @return true if the exception indicates ENOTSOCK, false otherwise
      */
     public static boolean isInvalidSocket(ZMQException thrown) {
-        return (thrown.getErrorCode() == ZMQ.Error.ENOTSOCK.getCode()
-            || thrown.getErrorCode() == ZMQ.Error.EAGAIN.getCode());
+        return thrown.getErrorCode() == ZMQ.Error.ENOTSOCK.getCode()
+            || thrown.getErrorCode() == ZMQ.Error.EAGAIN.getCode();
     }
 }

--- a/src/main/java/org/zeromq/jzmq/beacon/BeaconReactorBuilder.java
+++ b/src/main/java/org/zeromq/jzmq/beacon/BeaconReactorBuilder.java
@@ -49,7 +49,7 @@ public class BeaconReactorBuilder {
     }
 
     public BeaconReactor build() throws IOException {
-        assert (spec.listener != null);
+        assert spec.listener != null;
 
         BeaconReactorImpl reactor = new BeaconReactorImpl(context, spec.port, spec.beacon);
         reactor.setIgnoreLocalAddress(spec.ignoreLocalAddress);

--- a/src/main/java/org/zeromq/jzmq/beacon/BeaconReactorImpl.java
+++ b/src/main/java/org/zeromq/jzmq/beacon/BeaconReactorImpl.java
@@ -29,39 +29,6 @@ public class BeaconReactorImpl implements BeaconReactor {
     private long broadcastInterval = DEFAULT_BROADCAST_INTERVAL;
     private boolean ignoreLocalAddress = false;
 
-    public BeaconReactorImpl(ManagedContext context, int broadcastPort, UdpBeacon beacon) throws IOException {
-        this.context = context;
-        this.beacon = beacon;
-        this.socket = new UdpSocket(broadcastPort);
-        this.reactor = context.buildReactor()
-            .build();
-    }
-
-    @Override
-    public void start() {
-        assert (listener != null);
-        reactor.addTimer(broadcastInterval, -1, SEND_BEACON);
-        reactor.addPollable(context.newPollable(socket.getChannel(), PollerType.POLL_IN), RECEIVE_BEACON);
-        reactor.start();
-    }
-
-    @Override
-    public void stop() {
-        reactor.stop();
-    }
-
-    public void setListener(BeaconListener listener) {
-        this.listener = listener;
-    }
-
-    public void setBroadcastInterval(long broadcastInterval) {
-        this.broadcastInterval = broadcastInterval;
-    }
-
-    public void setIgnoreLocalAddress(boolean ignoreLocalAddress) {
-        this.ignoreLocalAddress = ignoreLocalAddress;
-    }
-
     private final LoopHandler SEND_BEACON = new LoopHandler() {
         @Override
         public void execute(Reactor reactor, Pollable pollable, Object... args) {
@@ -119,4 +86,37 @@ public class BeaconReactorImpl implements BeaconReactor {
             }
         }
     };
+    
+    public BeaconReactorImpl(ManagedContext context, int broadcastPort, UdpBeacon beacon) throws IOException {
+        this.context = context;
+        this.beacon = beacon;
+        this.socket = new UdpSocket(broadcastPort);
+        this.reactor = context.buildReactor()
+            .build();
+    }
+    
+    @Override
+    public void start() {
+        assert listener != null;
+        reactor.addTimer(broadcastInterval, -1, SEND_BEACON);
+        reactor.addPollable(context.newPollable(socket.getChannel(), PollerType.POLL_IN), RECEIVE_BEACON);
+        reactor.start();
+    }
+
+    @Override
+    public void stop() {
+        reactor.stop();
+    }
+
+    public void setListener(BeaconListener listener) {
+        this.listener = listener;
+    }
+
+    public void setBroadcastInterval(long broadcastInterval) {
+        this.broadcastInterval = broadcastInterval;
+    }
+
+    public void setIgnoreLocalAddress(boolean ignoreLocalAddress) {
+        this.ignoreLocalAddress = ignoreLocalAddress;
+    }  
 }

--- a/src/main/java/org/zeromq/jzmq/bstar/BinaryStarReactorBuilder.java
+++ b/src/main/java/org/zeromq/jzmq/bstar/BinaryStarReactorBuilder.java
@@ -84,8 +84,8 @@ public class BinaryStarReactorBuilder {
     }
 
     public BinaryStarReactor build() {
-        assert (spec.voter != null);
-        assert (spec.voterHandler != null);
+        assert spec.voter != null;
+        assert spec.voterHandler != null;
 
         BinaryStarReactor reactor = new BinaryStarReactorImpl(context, spec.mode, spec.local, spec.remote);
         reactor.registerVoterSocket(spec.voter);

--- a/src/main/java/org/zeromq/jzmq/bstar/BinaryStarSocketBuilder.java
+++ b/src/main/java/org/zeromq/jzmq/bstar/BinaryStarSocketBuilder.java
@@ -27,7 +27,7 @@ public class BinaryStarSocketBuilder extends ReqSocketBuilder {
         if (additionalUrls.length == 0) {
             socket = super.connect(url, additionalUrls);
         } else {
-            assert (additionalUrls.length == 1);
+            assert additionalUrls.length == 1;
             socket = fork(url, additionalUrls[0]);
         }
 

--- a/src/main/java/org/zeromq/jzmq/poll/PollerImpl.java
+++ b/src/main/java/org/zeromq/jzmq/poll/PollerImpl.java
@@ -144,7 +144,7 @@ public class PollerImpl implements Poller {
             }
         }
 
-        return (pollable != null);
+        return pollable != null;
     }
 
     private Pollable pollable(Socket socket) {
@@ -177,6 +177,6 @@ public class PollerImpl implements Poller {
             listeners.set(index, null);
         }
 
-        return (pollable != null);
+        return pollable != null;
     }
 }

--- a/src/main/java/org/zeromq/jzmq/reactor/ReactorTimer.java
+++ b/src/main/java/org/zeromq/jzmq/reactor/ReactorTimer.java
@@ -1,5 +1,7 @@
 package org.zeromq.jzmq.reactor;
 
+import java.util.Arrays;
+import java.util.Objects;
 import org.zeromq.api.LoopHandler;
 import org.zeromq.api.Reactor;
 
@@ -42,4 +44,42 @@ class ReactorTimer implements Comparable<ReactorTimer> {
 
         return result;
     }
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final ReactorTimer other = (ReactorTimer) obj;
+        if (this.initialDelay != other.initialDelay) {
+            return false;
+        }
+        if (this.numIterations != other.numIterations) {
+            return false;
+        }
+        if (this.nextFireTime != other.nextFireTime) {
+            return false;
+        }
+        if (!Objects.equals(this.handler, other.handler)) {
+            return false;
+        }
+        if (!Arrays.deepEquals(this.args, other.args)) {
+            return false;
+        }
+        return true;
+    }
+    
+    
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
squid:S1210 - "equals(Object obj)" should be overridden along with the "compareTo(T obj)" method.
squid:S1873 - "static final" arrays should be "private".
squid:S2386 - Mutable fields should not be "public static".
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
squid:S1155 - Collection.isEmpty() should be used to test for emptiness.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1213
https://dev.eclipse.org/sonar/rules/show/squid:S1210
https://dev.eclipse.org/sonar/rules/show/squid:S1873
https://dev.eclipse.org/sonar/rules/show/squid:S2386
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1155
Please let me know if you have any questions.
George Kankava