### PR TITLE
Flip ByteBuffer when building a new frame

### DIFF
--- a/src/main/java/org/zeromq/api/Message.java
+++ b/src/main/java/org/zeromq/api/Message.java
@@ -1083,6 +1083,7 @@ public class Message implements Iterable<Message.Frame> {
          * @return The new frame
          */
         public Frame build() {
+            buffer.flip();
             return new Frame(buffer);
         }
 

--- a/src/test/java/org/zeromq/api/MessageTest.java
+++ b/src/test/java/org/zeromq/api/MessageTest.java
@@ -89,6 +89,12 @@ public class MessageTest {
     }
 
     @Test
+    public void testGetInt() {
+        Frame frame = Frame.of(100);
+        assertEquals(100, frame.getInt());
+    }
+
+    @Test
     public void testPutInt_0x77777777() {
         Frame frame = Frame.of(0x77777777);
 


### PR DESCRIPTION
Problem: FrameBuilder does not flip ByteBuffer when building a new frame.
Solution: Flip ByteBuffer when building a new frame.

Closes #42