### PR TITLE
Fix deprecation warnings

### DIFF
--- a/src/main/java/org/zeromq/api/SocketType.java
+++ b/src/main/java/org/zeromq/api/SocketType.java
@@ -8,60 +8,60 @@ public enum SocketType {
      * A socket of type ZMQ_PAIR can only be connected to a single peer at any one time. No message routing or filtering
      * is performed on messages sent over a ZMQ_PAIR socket.
      */
-    PAIR(0),
+    PAIR(org.zeromq.SocketType.PAIR),
     /**
      * A socket of type ZMQ_PUB is used by a publisher to distribute data. Messages sent are distributed in a fan out
      * fashion to all connected peers.
      */
-    PUB(1),
+    PUB(org.zeromq.SocketType.PUB),
     /**
      * A socket of type ZMQ_SUB is used by a subscriber to subscribe to data distributed by a publisher. Initially a
      * ZMQ_SUB socket is not subscribed to any messages.
      */
-    SUB(2),
+    SUB(org.zeromq.SocketType.SUB),
     /**
      * A socket of type ZMQ_REP is used by a service to receive requests from and send replies to a client. This socket
      * type allows only an alternating sequence of receive(request) and subsequent send(reply) calls.
      */
-    REQ(3),
+    REQ(org.zeromq.SocketType.REQ),
     /**
      * A socket of type ZMQ_REQ is used by a client to send requests to and receive replies from a service. This socket
      * type allows only an alternating sequence of send(request) and subsequent receive(reply) calls.
      */
-    REP(4),
+    REP(org.zeromq.SocketType.REP),
     /**
      * A socket of type ZMQ_DEALER is an advanced pattern used for extending request/reply sockets. Each message sent is
      * round-robined among all connected peers, and each message received is fair-queued from all connected peers.
      */
-    DEALER(5),
+    DEALER(org.zeromq.SocketType.DEALER),
     /**
      * A socket of type ZMQ_ROUTER is an advanced socket type used for extending request/reply sockets. When receiving
      * messages a ZMQ_ROUTER socket shall prepend a message part containing the identity of the originating peer to the
      * message before passing it to the application.
      */
-    ROUTER(6),
+    ROUTER(org.zeromq.SocketType.ROUTER),
     /**
      * A socket of type ZMQ_PULL is used by a pipeline node to receive messages from upstream pipeline nodes. Messages
      * are fair-queued from among all connected upstream nodes.
      */
-    PULL(7),
+    PULL(org.zeromq.SocketType.PULL),
     /**
      * A socket of type ZMQ_PUSH is used by a pipeline node to send messages to downstream pipeline nodes. Messages are
      * round-robined to all connected downstream nodes.
      */
-    PUSH(8),
+    PUSH(org.zeromq.SocketType.PUSH),
     /**
      * Same as ZMQ_PUB except that you can receive subscriptions from the peers in form of incoming messages.
      */
-    XPUB(9),
+    XPUB(org.zeromq.SocketType.XPUB),
     /**
      * Same as ZMQ_SUB except that you subscribe by sending subscription messages to the socket.
      */
-    XSUB(10);
+    XSUB(org.zeromq.SocketType.XSUB);
 
-    private final int type;
+    private final org.zeromq.SocketType type;
 
-    private SocketType(int type) {
+    SocketType(org.zeromq.SocketType type) {
         this.type = type;
     }
 
@@ -70,7 +70,7 @@ public enum SocketType {
      * 
      * @return socket type
      */
-    public int getType() {
+    public org.zeromq.SocketType getType() {
         return type;
     }
 }

--- a/src/main/java/org/zeromq/jzmq/sockets/SocketBuilder.java
+++ b/src/main/java/org/zeromq/jzmq/sockets/SocketBuilder.java
@@ -25,9 +25,9 @@ public class SocketBuilder implements Bindable, Connectable {
 
     public class SocketSpec {
         public long swapSize;
-        public long linger;
-        public long sendHighwatermark;
-        public long receiveHighWatermark;
+        public int linger;
+        public int sendHighwatermark;
+        public int receiveHighWatermark;
         public int receiveTimeout = -1;
         public int sendTimeout = -1;
         public SocketType socketType;
@@ -57,8 +57,22 @@ public class SocketBuilder implements Bindable, Connectable {
      * 
      * @param lingerMS the linger period in millis
      * @return builder object
+     * @deprecated The linger option has only integer range, use {@link SocketBuilder#withLinger(int)} instead.
      */
+    @Deprecated
     public SocketBuilder withLinger(long lingerMS) {
+        getSocketSpec().linger = Long.valueOf(lingerMS).intValue();
+        return this;
+    }
+
+    /**
+     * Set the linger period for the specified socket. The linger period determines how long pending which have yet to
+     * sent to a peer shall linger in memory after a socket is closed.
+     *
+     * @param lingerMS the linger period in millis
+     * @return builder object
+     */
+    public SocketBuilder withLinger(int lingerMS) {
         getSocketSpec().linger = lingerMS;
         return this;
     }
@@ -68,7 +82,7 @@ public class SocketBuilder implements Bindable, Connectable {
      * 
      * @return linger period
      */
-    public long getLinger() {
+    public int getLinger() {
         return getSocketSpec().linger;
     }
 
@@ -125,8 +139,21 @@ public class SocketBuilder implements Bindable, Connectable {
      * 
      * @param sendHWM The send high watermark
      * @return builder object
+     * @deprecated This option uses integer range, use {@link SocketBuilder#withSendHighWatermark(int)} instead.
      */
+    @Deprecated
     public SocketBuilder withSendHighWatermark(long sendHWM) {
+        getSocketSpec().sendHighwatermark = Long.valueOf(sendHWM).intValue();
+        return this;
+    }
+
+    /**
+     * Set the send high watermark.
+     *
+     * @param sendHWM The send high watermark
+     * @return builder object
+     */
+    public SocketBuilder withSendHighWatermark(int sendHWM) {
         getSocketSpec().sendHighwatermark = sendHWM;
         return this;
     }
@@ -136,7 +163,7 @@ public class SocketBuilder implements Bindable, Connectable {
      * 
      * @return send high watermark
      */
-    public long getSendHighWaterMark() {
+    public int getSendHighWaterMark() {
         return getSocketSpec().sendHighwatermark;
     }
 
@@ -152,8 +179,28 @@ public class SocketBuilder implements Bindable, Connectable {
      * 
      * @param receiveHWM recv high water mark
      * @return builder object
+     * @deprecated This option uses integer range, use {@link #withReceiveHighWatermark(int)} instead.
      */
+    @Deprecated
     public SocketBuilder withReceiveHighWatermark(long receiveHWM) {
+        getSocketSpec().receiveHighWatermark = Long.valueOf(receiveHWM).intValue();
+        return this;
+    }
+
+    /**
+     * The RECVHWM option shall set the high water mark (HWM) for inbound messages on the specified socket. The HWM is a
+     * hard limit on the maximum number of outstanding 0MQ shall queue in memory for any single peer that the specified
+     * socket is communicating with.
+     *
+     * If this limit has been reached the socket shall enter an exceptional state and depending on the socket type, 0MQ
+     * shall take appropriate action such as blocking or dropping sent messages. Refer to the individual socket
+     * descriptions in <a href="http://api.zeromq.org/3-2:zmq-socket">zmq_socket(3)</a> for details on the exact action
+     * taken for each socket type.
+     *
+     * @param receiveHWM recv high water mark
+     * @return builder object
+     */
+    public SocketBuilder withReceiveHighWatermark(int receiveHWM) {
         getSocketSpec().receiveHighWatermark = receiveHWM;
         return this;
     }
@@ -163,7 +210,7 @@ public class SocketBuilder implements Bindable, Connectable {
      * 
      * @return receive high water mark
      */
-    public long getReceiveHighWaterMark() {
+    public int getReceiveHighWaterMark() {
         return getSocketSpec().receiveHighWatermark;
     }
 


### PR DESCRIPTION
**Problem:** jzmq-api has a few deprecation warnings in recent versions of jeromq.
**Solution:** Deprecate a few methods and utilize new socket option methods in jeromq.