### PR TITLE
Added maven-gpg-plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,6 +169,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.6</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>


### PR DESCRIPTION
**Problem:** Build is malformed due to missing plugin version.
**Solution:** Add plugin version for maven-gpg-plugin.